### PR TITLE
Aurora 0.17.0 Compatibility changes

### DIFF
--- a/auroraAPI.thrift
+++ b/auroraAPI.thrift
@@ -203,6 +203,8 @@ union Image {
 struct MesosContainer {
   /** the optional filesystem image to use when launching this task. */
   1: optional Image image
+  /** the optional list of volumes to mount into the task. */
+  2: optional list<Volume> volumes
 }
 
 /** Describes a parameter passed to docker cli */
@@ -1073,7 +1075,7 @@ service AuroraSchedulerManager extends ReadOnlyScheduler {
   Response restartShards(5: JobKey job, 3: set<i32> shardIds)
 
   /** Initiates a kill on tasks. */
-  Response killTasks(4: JobKey job, 5: set<i32> instances)
+  Response killTasks(4: JobKey job, 5: set<i32> instances, 6: string message)
 
   /**
    * Adds new instances with the TaskConfig of the existing instance pointed by the key.

--- a/gen-go/apache/aurora/aurora_admin-remote/aurora_admin-remote.go
+++ b/gen-go/apache/aurora/aurora_admin-remote/aurora_admin-remote.go
@@ -42,7 +42,7 @@ func Usage() {
 	fmt.Fprintln(os.Stderr, "  Response descheduleCronJob(JobKey job)")
 	fmt.Fprintln(os.Stderr, "  Response startCronJob(JobKey job)")
 	fmt.Fprintln(os.Stderr, "  Response restartShards(JobKey job,  shardIds)")
-	fmt.Fprintln(os.Stderr, "  Response killTasks(JobKey job,  instances)")
+	fmt.Fprintln(os.Stderr, "  Response killTasks(JobKey job,  instances, string message)")
 	fmt.Fprintln(os.Stderr, "  Response addInstances(InstanceKey key, i32 count)")
 	fmt.Fprintln(os.Stderr, "  Response replaceCronTemplate(JobConfiguration config)")
 	fmt.Fprintln(os.Stderr, "  Response startJobUpdate(JobUpdateRequest request, string message)")
@@ -165,19 +165,19 @@ func main() {
 		}
 		argvalue0 := flag.Arg(1)
 		value0 := argvalue0
-		arg352 := flag.Arg(2)
-		mbTrans353 := thrift.NewTMemoryBufferLen(len(arg352))
-		defer mbTrans353.Close()
-		_, err354 := mbTrans353.WriteString(arg352)
-		if err354 != nil {
+		arg354 := flag.Arg(2)
+		mbTrans355 := thrift.NewTMemoryBufferLen(len(arg354))
+		defer mbTrans355.Close()
+		_, err356 := mbTrans355.WriteString(arg354)
+		if err356 != nil {
 			Usage()
 			return
 		}
-		factory355 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt356 := factory355.GetProtocol(mbTrans353)
+		factory357 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt358 := factory357.GetProtocol(mbTrans355)
 		argvalue1 := aurora.NewResourceAggregate()
-		err357 := argvalue1.Read(jsProt356)
-		if err357 != nil {
+		err359 := argvalue1.Read(jsProt358)
+		if err359 != nil {
 			Usage()
 			return
 		}
@@ -233,19 +233,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "QueryRecovery requires 1 args")
 			flag.Usage()
 		}
-		arg360 := flag.Arg(1)
-		mbTrans361 := thrift.NewTMemoryBufferLen(len(arg360))
-		defer mbTrans361.Close()
-		_, err362 := mbTrans361.WriteString(arg360)
-		if err362 != nil {
+		arg362 := flag.Arg(1)
+		mbTrans363 := thrift.NewTMemoryBufferLen(len(arg362))
+		defer mbTrans363.Close()
+		_, err364 := mbTrans363.WriteString(arg362)
+		if err364 != nil {
 			Usage()
 			return
 		}
-		factory363 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt364 := factory363.GetProtocol(mbTrans361)
+		factory365 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt366 := factory365.GetProtocol(mbTrans363)
 		argvalue0 := aurora.NewTaskQuery()
-		err365 := argvalue0.Read(jsProt364)
-		if err365 != nil {
+		err367 := argvalue0.Read(jsProt366)
+		if err367 != nil {
 			Usage()
 			return
 		}
@@ -258,19 +258,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "DeleteRecoveryTasks requires 1 args")
 			flag.Usage()
 		}
-		arg366 := flag.Arg(1)
-		mbTrans367 := thrift.NewTMemoryBufferLen(len(arg366))
-		defer mbTrans367.Close()
-		_, err368 := mbTrans367.WriteString(arg366)
-		if err368 != nil {
+		arg368 := flag.Arg(1)
+		mbTrans369 := thrift.NewTMemoryBufferLen(len(arg368))
+		defer mbTrans369.Close()
+		_, err370 := mbTrans369.WriteString(arg368)
+		if err370 != nil {
 			Usage()
 			return
 		}
-		factory369 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt370 := factory369.GetProtocol(mbTrans367)
+		factory371 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt372 := factory371.GetProtocol(mbTrans369)
 		argvalue0 := aurora.NewTaskQuery()
-		err371 := argvalue0.Read(jsProt370)
-		if err371 != nil {
+		err373 := argvalue0.Read(jsProt372)
+		if err373 != nil {
 			Usage()
 			return
 		}
@@ -299,19 +299,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartMaintenance requires 1 args")
 			flag.Usage()
 		}
-		arg372 := flag.Arg(1)
-		mbTrans373 := thrift.NewTMemoryBufferLen(len(arg372))
-		defer mbTrans373.Close()
-		_, err374 := mbTrans373.WriteString(arg372)
-		if err374 != nil {
+		arg374 := flag.Arg(1)
+		mbTrans375 := thrift.NewTMemoryBufferLen(len(arg374))
+		defer mbTrans375.Close()
+		_, err376 := mbTrans375.WriteString(arg374)
+		if err376 != nil {
 			Usage()
 			return
 		}
-		factory375 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt376 := factory375.GetProtocol(mbTrans373)
+		factory377 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt378 := factory377.GetProtocol(mbTrans375)
 		argvalue0 := aurora.NewHosts()
-		err377 := argvalue0.Read(jsProt376)
-		if err377 != nil {
+		err379 := argvalue0.Read(jsProt378)
+		if err379 != nil {
 			Usage()
 			return
 		}
@@ -324,19 +324,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "DrainHosts requires 1 args")
 			flag.Usage()
 		}
-		arg378 := flag.Arg(1)
-		mbTrans379 := thrift.NewTMemoryBufferLen(len(arg378))
-		defer mbTrans379.Close()
-		_, err380 := mbTrans379.WriteString(arg378)
-		if err380 != nil {
+		arg380 := flag.Arg(1)
+		mbTrans381 := thrift.NewTMemoryBufferLen(len(arg380))
+		defer mbTrans381.Close()
+		_, err382 := mbTrans381.WriteString(arg380)
+		if err382 != nil {
 			Usage()
 			return
 		}
-		factory381 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt382 := factory381.GetProtocol(mbTrans379)
+		factory383 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt384 := factory383.GetProtocol(mbTrans381)
 		argvalue0 := aurora.NewHosts()
-		err383 := argvalue0.Read(jsProt382)
-		if err383 != nil {
+		err385 := argvalue0.Read(jsProt384)
+		if err385 != nil {
 			Usage()
 			return
 		}
@@ -349,19 +349,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "MaintenanceStatus requires 1 args")
 			flag.Usage()
 		}
-		arg384 := flag.Arg(1)
-		mbTrans385 := thrift.NewTMemoryBufferLen(len(arg384))
-		defer mbTrans385.Close()
-		_, err386 := mbTrans385.WriteString(arg384)
-		if err386 != nil {
+		arg386 := flag.Arg(1)
+		mbTrans387 := thrift.NewTMemoryBufferLen(len(arg386))
+		defer mbTrans387.Close()
+		_, err388 := mbTrans387.WriteString(arg386)
+		if err388 != nil {
 			Usage()
 			return
 		}
-		factory387 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt388 := factory387.GetProtocol(mbTrans385)
+		factory389 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt390 := factory389.GetProtocol(mbTrans387)
 		argvalue0 := aurora.NewHosts()
-		err389 := argvalue0.Read(jsProt388)
-		if err389 != nil {
+		err391 := argvalue0.Read(jsProt390)
+		if err391 != nil {
 			Usage()
 			return
 		}
@@ -374,19 +374,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "EndMaintenance requires 1 args")
 			flag.Usage()
 		}
-		arg390 := flag.Arg(1)
-		mbTrans391 := thrift.NewTMemoryBufferLen(len(arg390))
-		defer mbTrans391.Close()
-		_, err392 := mbTrans391.WriteString(arg390)
-		if err392 != nil {
+		arg392 := flag.Arg(1)
+		mbTrans393 := thrift.NewTMemoryBufferLen(len(arg392))
+		defer mbTrans393.Close()
+		_, err394 := mbTrans393.WriteString(arg392)
+		if err394 != nil {
 			Usage()
 			return
 		}
-		factory393 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt394 := factory393.GetProtocol(mbTrans391)
+		factory395 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt396 := factory395.GetProtocol(mbTrans393)
 		argvalue0 := aurora.NewHosts()
-		err395 := argvalue0.Read(jsProt394)
-		if err395 != nil {
+		err397 := argvalue0.Read(jsProt396)
+		if err397 != nil {
 			Usage()
 			return
 		}
@@ -407,19 +407,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RewriteConfigs requires 1 args")
 			flag.Usage()
 		}
-		arg396 := flag.Arg(1)
-		mbTrans397 := thrift.NewTMemoryBufferLen(len(arg396))
-		defer mbTrans397.Close()
-		_, err398 := mbTrans397.WriteString(arg396)
-		if err398 != nil {
+		arg398 := flag.Arg(1)
+		mbTrans399 := thrift.NewTMemoryBufferLen(len(arg398))
+		defer mbTrans399.Close()
+		_, err400 := mbTrans399.WriteString(arg398)
+		if err400 != nil {
 			Usage()
 			return
 		}
-		factory399 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt400 := factory399.GetProtocol(mbTrans397)
+		factory401 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt402 := factory401.GetProtocol(mbTrans399)
 		argvalue0 := aurora.NewRewriteConfigsRequest()
-		err401 := argvalue0.Read(jsProt400)
-		if err401 != nil {
+		err403 := argvalue0.Read(jsProt402)
+		if err403 != nil {
 			Usage()
 			return
 		}
@@ -432,19 +432,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "TriggerExplicitTaskReconciliation requires 1 args")
 			flag.Usage()
 		}
-		arg402 := flag.Arg(1)
-		mbTrans403 := thrift.NewTMemoryBufferLen(len(arg402))
-		defer mbTrans403.Close()
-		_, err404 := mbTrans403.WriteString(arg402)
-		if err404 != nil {
+		arg404 := flag.Arg(1)
+		mbTrans405 := thrift.NewTMemoryBufferLen(len(arg404))
+		defer mbTrans405.Close()
+		_, err406 := mbTrans405.WriteString(arg404)
+		if err406 != nil {
 			Usage()
 			return
 		}
-		factory405 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt406 := factory405.GetProtocol(mbTrans403)
+		factory407 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt408 := factory407.GetProtocol(mbTrans405)
 		argvalue0 := aurora.NewExplicitReconciliationSettings()
-		err407 := argvalue0.Read(jsProt406)
-		if err407 != nil {
+		err409 := argvalue0.Read(jsProt408)
+		if err409 != nil {
 			Usage()
 			return
 		}
@@ -465,19 +465,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "CreateJob requires 1 args")
 			flag.Usage()
 		}
-		arg408 := flag.Arg(1)
-		mbTrans409 := thrift.NewTMemoryBufferLen(len(arg408))
-		defer mbTrans409.Close()
-		_, err410 := mbTrans409.WriteString(arg408)
-		if err410 != nil {
+		arg410 := flag.Arg(1)
+		mbTrans411 := thrift.NewTMemoryBufferLen(len(arg410))
+		defer mbTrans411.Close()
+		_, err412 := mbTrans411.WriteString(arg410)
+		if err412 != nil {
 			Usage()
 			return
 		}
-		factory411 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt412 := factory411.GetProtocol(mbTrans409)
+		factory413 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt414 := factory413.GetProtocol(mbTrans411)
 		argvalue0 := aurora.NewJobConfiguration()
-		err413 := argvalue0.Read(jsProt412)
-		if err413 != nil {
+		err415 := argvalue0.Read(jsProt414)
+		if err415 != nil {
 			Usage()
 			return
 		}
@@ -490,19 +490,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ScheduleCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg414 := flag.Arg(1)
-		mbTrans415 := thrift.NewTMemoryBufferLen(len(arg414))
-		defer mbTrans415.Close()
-		_, err416 := mbTrans415.WriteString(arg414)
-		if err416 != nil {
+		arg416 := flag.Arg(1)
+		mbTrans417 := thrift.NewTMemoryBufferLen(len(arg416))
+		defer mbTrans417.Close()
+		_, err418 := mbTrans417.WriteString(arg416)
+		if err418 != nil {
 			Usage()
 			return
 		}
-		factory417 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt418 := factory417.GetProtocol(mbTrans415)
+		factory419 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt420 := factory419.GetProtocol(mbTrans417)
 		argvalue0 := aurora.NewJobConfiguration()
-		err419 := argvalue0.Read(jsProt418)
-		if err419 != nil {
+		err421 := argvalue0.Read(jsProt420)
+		if err421 != nil {
 			Usage()
 			return
 		}
@@ -515,19 +515,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "DescheduleCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg420 := flag.Arg(1)
-		mbTrans421 := thrift.NewTMemoryBufferLen(len(arg420))
-		defer mbTrans421.Close()
-		_, err422 := mbTrans421.WriteString(arg420)
-		if err422 != nil {
+		arg422 := flag.Arg(1)
+		mbTrans423 := thrift.NewTMemoryBufferLen(len(arg422))
+		defer mbTrans423.Close()
+		_, err424 := mbTrans423.WriteString(arg422)
+		if err424 != nil {
 			Usage()
 			return
 		}
-		factory423 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt424 := factory423.GetProtocol(mbTrans421)
+		factory425 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt426 := factory425.GetProtocol(mbTrans423)
 		argvalue0 := aurora.NewJobKey()
-		err425 := argvalue0.Read(jsProt424)
-		if err425 != nil {
+		err427 := argvalue0.Read(jsProt426)
+		if err427 != nil {
 			Usage()
 			return
 		}
@@ -540,19 +540,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg426 := flag.Arg(1)
-		mbTrans427 := thrift.NewTMemoryBufferLen(len(arg426))
-		defer mbTrans427.Close()
-		_, err428 := mbTrans427.WriteString(arg426)
-		if err428 != nil {
+		arg428 := flag.Arg(1)
+		mbTrans429 := thrift.NewTMemoryBufferLen(len(arg428))
+		defer mbTrans429.Close()
+		_, err430 := mbTrans429.WriteString(arg428)
+		if err430 != nil {
 			Usage()
 			return
 		}
-		factory429 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt430 := factory429.GetProtocol(mbTrans427)
+		factory431 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt432 := factory431.GetProtocol(mbTrans429)
 		argvalue0 := aurora.NewJobKey()
-		err431 := argvalue0.Read(jsProt430)
-		if err431 != nil {
+		err433 := argvalue0.Read(jsProt432)
+		if err433 != nil {
 			Usage()
 			return
 		}
@@ -565,36 +565,36 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RestartShards requires 2 args")
 			flag.Usage()
 		}
-		arg432 := flag.Arg(1)
-		mbTrans433 := thrift.NewTMemoryBufferLen(len(arg432))
-		defer mbTrans433.Close()
-		_, err434 := mbTrans433.WriteString(arg432)
-		if err434 != nil {
+		arg434 := flag.Arg(1)
+		mbTrans435 := thrift.NewTMemoryBufferLen(len(arg434))
+		defer mbTrans435.Close()
+		_, err436 := mbTrans435.WriteString(arg434)
+		if err436 != nil {
 			Usage()
 			return
 		}
-		factory435 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt436 := factory435.GetProtocol(mbTrans433)
+		factory437 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt438 := factory437.GetProtocol(mbTrans435)
 		argvalue0 := aurora.NewJobKey()
-		err437 := argvalue0.Read(jsProt436)
-		if err437 != nil {
+		err439 := argvalue0.Read(jsProt438)
+		if err439 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
-		arg438 := flag.Arg(2)
-		mbTrans439 := thrift.NewTMemoryBufferLen(len(arg438))
-		defer mbTrans439.Close()
-		_, err440 := mbTrans439.WriteString(arg438)
-		if err440 != nil {
+		arg440 := flag.Arg(2)
+		mbTrans441 := thrift.NewTMemoryBufferLen(len(arg440))
+		defer mbTrans441.Close()
+		_, err442 := mbTrans441.WriteString(arg440)
+		if err442 != nil {
 			Usage()
 			return
 		}
-		factory441 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt442 := factory441.GetProtocol(mbTrans439)
+		factory443 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt444 := factory443.GetProtocol(mbTrans441)
 		containerStruct1 := aurora.NewAuroraAdminRestartShardsArgs()
-		err443 := containerStruct1.ReadField2(jsProt442)
-		if err443 != nil {
+		err445 := containerStruct1.ReadField2(jsProt444)
+		if err445 != nil {
 			Usage()
 			return
 		}
@@ -604,46 +604,48 @@ func main() {
 		fmt.Print("\n")
 		break
 	case "killTasks":
-		if flag.NArg()-1 != 2 {
-			fmt.Fprintln(os.Stderr, "KillTasks requires 2 args")
+		if flag.NArg()-1 != 3 {
+			fmt.Fprintln(os.Stderr, "KillTasks requires 3 args")
 			flag.Usage()
 		}
-		arg444 := flag.Arg(1)
-		mbTrans445 := thrift.NewTMemoryBufferLen(len(arg444))
-		defer mbTrans445.Close()
-		_, err446 := mbTrans445.WriteString(arg444)
-		if err446 != nil {
+		arg446 := flag.Arg(1)
+		mbTrans447 := thrift.NewTMemoryBufferLen(len(arg446))
+		defer mbTrans447.Close()
+		_, err448 := mbTrans447.WriteString(arg446)
+		if err448 != nil {
 			Usage()
 			return
 		}
-		factory447 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt448 := factory447.GetProtocol(mbTrans445)
+		factory449 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt450 := factory449.GetProtocol(mbTrans447)
 		argvalue0 := aurora.NewJobKey()
-		err449 := argvalue0.Read(jsProt448)
-		if err449 != nil {
+		err451 := argvalue0.Read(jsProt450)
+		if err451 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
-		arg450 := flag.Arg(2)
-		mbTrans451 := thrift.NewTMemoryBufferLen(len(arg450))
-		defer mbTrans451.Close()
-		_, err452 := mbTrans451.WriteString(arg450)
-		if err452 != nil {
+		arg452 := flag.Arg(2)
+		mbTrans453 := thrift.NewTMemoryBufferLen(len(arg452))
+		defer mbTrans453.Close()
+		_, err454 := mbTrans453.WriteString(arg452)
+		if err454 != nil {
 			Usage()
 			return
 		}
-		factory453 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt454 := factory453.GetProtocol(mbTrans451)
+		factory455 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt456 := factory455.GetProtocol(mbTrans453)
 		containerStruct1 := aurora.NewAuroraAdminKillTasksArgs()
-		err455 := containerStruct1.ReadField2(jsProt454)
-		if err455 != nil {
+		err457 := containerStruct1.ReadField2(jsProt456)
+		if err457 != nil {
 			Usage()
 			return
 		}
 		argvalue1 := containerStruct1.Instances
 		value1 := argvalue1
-		fmt.Print(client.KillTasks(value0, value1))
+		argvalue2 := flag.Arg(3)
+		value2 := argvalue2
+		fmt.Print(client.KillTasks(value0, value1, value2))
 		fmt.Print("\n")
 		break
 	case "addInstances":
@@ -651,25 +653,25 @@ func main() {
 			fmt.Fprintln(os.Stderr, "AddInstances requires 2 args")
 			flag.Usage()
 		}
-		arg456 := flag.Arg(1)
-		mbTrans457 := thrift.NewTMemoryBufferLen(len(arg456))
-		defer mbTrans457.Close()
-		_, err458 := mbTrans457.WriteString(arg456)
-		if err458 != nil {
-			Usage()
-			return
-		}
-		factory459 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt460 := factory459.GetProtocol(mbTrans457)
-		argvalue0 := aurora.NewInstanceKey()
-		err461 := argvalue0.Read(jsProt460)
+		arg459 := flag.Arg(1)
+		mbTrans460 := thrift.NewTMemoryBufferLen(len(arg459))
+		defer mbTrans460.Close()
+		_, err461 := mbTrans460.WriteString(arg459)
 		if err461 != nil {
 			Usage()
 			return
 		}
+		factory462 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt463 := factory462.GetProtocol(mbTrans460)
+		argvalue0 := aurora.NewInstanceKey()
+		err464 := argvalue0.Read(jsProt463)
+		if err464 != nil {
+			Usage()
+			return
+		}
 		value0 := argvalue0
-		tmp1, err462 := (strconv.Atoi(flag.Arg(2)))
-		if err462 != nil {
+		tmp1, err465 := (strconv.Atoi(flag.Arg(2)))
+		if err465 != nil {
 			Usage()
 			return
 		}
@@ -683,19 +685,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ReplaceCronTemplate requires 1 args")
 			flag.Usage()
 		}
-		arg463 := flag.Arg(1)
-		mbTrans464 := thrift.NewTMemoryBufferLen(len(arg463))
-		defer mbTrans464.Close()
-		_, err465 := mbTrans464.WriteString(arg463)
-		if err465 != nil {
+		arg466 := flag.Arg(1)
+		mbTrans467 := thrift.NewTMemoryBufferLen(len(arg466))
+		defer mbTrans467.Close()
+		_, err468 := mbTrans467.WriteString(arg466)
+		if err468 != nil {
 			Usage()
 			return
 		}
-		factory466 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt467 := factory466.GetProtocol(mbTrans464)
+		factory469 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt470 := factory469.GetProtocol(mbTrans467)
 		argvalue0 := aurora.NewJobConfiguration()
-		err468 := argvalue0.Read(jsProt467)
-		if err468 != nil {
+		err471 := argvalue0.Read(jsProt470)
+		if err471 != nil {
 			Usage()
 			return
 		}
@@ -708,19 +710,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg469 := flag.Arg(1)
-		mbTrans470 := thrift.NewTMemoryBufferLen(len(arg469))
-		defer mbTrans470.Close()
-		_, err471 := mbTrans470.WriteString(arg469)
-		if err471 != nil {
+		arg472 := flag.Arg(1)
+		mbTrans473 := thrift.NewTMemoryBufferLen(len(arg472))
+		defer mbTrans473.Close()
+		_, err474 := mbTrans473.WriteString(arg472)
+		if err474 != nil {
 			Usage()
 			return
 		}
-		factory472 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt473 := factory472.GetProtocol(mbTrans470)
+		factory475 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt476 := factory475.GetProtocol(mbTrans473)
 		argvalue0 := aurora.NewJobUpdateRequest()
-		err474 := argvalue0.Read(jsProt473)
-		if err474 != nil {
+		err477 := argvalue0.Read(jsProt476)
+		if err477 != nil {
 			Usage()
 			return
 		}
@@ -735,19 +737,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PauseJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg476 := flag.Arg(1)
-		mbTrans477 := thrift.NewTMemoryBufferLen(len(arg476))
-		defer mbTrans477.Close()
-		_, err478 := mbTrans477.WriteString(arg476)
-		if err478 != nil {
+		arg479 := flag.Arg(1)
+		mbTrans480 := thrift.NewTMemoryBufferLen(len(arg479))
+		defer mbTrans480.Close()
+		_, err481 := mbTrans480.WriteString(arg479)
+		if err481 != nil {
 			Usage()
 			return
 		}
-		factory479 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt480 := factory479.GetProtocol(mbTrans477)
+		factory482 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt483 := factory482.GetProtocol(mbTrans480)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err481 := argvalue0.Read(jsProt480)
-		if err481 != nil {
+		err484 := argvalue0.Read(jsProt483)
+		if err484 != nil {
 			Usage()
 			return
 		}
@@ -762,19 +764,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ResumeJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg483 := flag.Arg(1)
-		mbTrans484 := thrift.NewTMemoryBufferLen(len(arg483))
-		defer mbTrans484.Close()
-		_, err485 := mbTrans484.WriteString(arg483)
-		if err485 != nil {
+		arg486 := flag.Arg(1)
+		mbTrans487 := thrift.NewTMemoryBufferLen(len(arg486))
+		defer mbTrans487.Close()
+		_, err488 := mbTrans487.WriteString(arg486)
+		if err488 != nil {
 			Usage()
 			return
 		}
-		factory486 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt487 := factory486.GetProtocol(mbTrans484)
+		factory489 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt490 := factory489.GetProtocol(mbTrans487)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err488 := argvalue0.Read(jsProt487)
-		if err488 != nil {
+		err491 := argvalue0.Read(jsProt490)
+		if err491 != nil {
 			Usage()
 			return
 		}
@@ -789,19 +791,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "AbortJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg490 := flag.Arg(1)
-		mbTrans491 := thrift.NewTMemoryBufferLen(len(arg490))
-		defer mbTrans491.Close()
-		_, err492 := mbTrans491.WriteString(arg490)
-		if err492 != nil {
+		arg493 := flag.Arg(1)
+		mbTrans494 := thrift.NewTMemoryBufferLen(len(arg493))
+		defer mbTrans494.Close()
+		_, err495 := mbTrans494.WriteString(arg493)
+		if err495 != nil {
 			Usage()
 			return
 		}
-		factory493 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt494 := factory493.GetProtocol(mbTrans491)
+		factory496 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt497 := factory496.GetProtocol(mbTrans494)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err495 := argvalue0.Read(jsProt494)
-		if err495 != nil {
+		err498 := argvalue0.Read(jsProt497)
+		if err498 != nil {
 			Usage()
 			return
 		}
@@ -816,19 +818,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RollbackJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg497 := flag.Arg(1)
-		mbTrans498 := thrift.NewTMemoryBufferLen(len(arg497))
-		defer mbTrans498.Close()
-		_, err499 := mbTrans498.WriteString(arg497)
-		if err499 != nil {
+		arg500 := flag.Arg(1)
+		mbTrans501 := thrift.NewTMemoryBufferLen(len(arg500))
+		defer mbTrans501.Close()
+		_, err502 := mbTrans501.WriteString(arg500)
+		if err502 != nil {
 			Usage()
 			return
 		}
-		factory500 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt501 := factory500.GetProtocol(mbTrans498)
+		factory503 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt504 := factory503.GetProtocol(mbTrans501)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err502 := argvalue0.Read(jsProt501)
-		if err502 != nil {
+		err505 := argvalue0.Read(jsProt504)
+		if err505 != nil {
 			Usage()
 			return
 		}
@@ -843,19 +845,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PulseJobUpdate requires 1 args")
 			flag.Usage()
 		}
-		arg504 := flag.Arg(1)
-		mbTrans505 := thrift.NewTMemoryBufferLen(len(arg504))
-		defer mbTrans505.Close()
-		_, err506 := mbTrans505.WriteString(arg504)
-		if err506 != nil {
+		arg507 := flag.Arg(1)
+		mbTrans508 := thrift.NewTMemoryBufferLen(len(arg507))
+		defer mbTrans508.Close()
+		_, err509 := mbTrans508.WriteString(arg507)
+		if err509 != nil {
 			Usage()
 			return
 		}
-		factory507 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt508 := factory507.GetProtocol(mbTrans505)
+		factory510 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt511 := factory510.GetProtocol(mbTrans508)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err509 := argvalue0.Read(jsProt508)
-		if err509 != nil {
+		err512 := argvalue0.Read(jsProt511)
+		if err512 != nil {
 			Usage()
 			return
 		}
@@ -886,19 +888,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksStatus requires 1 args")
 			flag.Usage()
 		}
-		arg511 := flag.Arg(1)
-		mbTrans512 := thrift.NewTMemoryBufferLen(len(arg511))
-		defer mbTrans512.Close()
-		_, err513 := mbTrans512.WriteString(arg511)
-		if err513 != nil {
+		arg514 := flag.Arg(1)
+		mbTrans515 := thrift.NewTMemoryBufferLen(len(arg514))
+		defer mbTrans515.Close()
+		_, err516 := mbTrans515.WriteString(arg514)
+		if err516 != nil {
 			Usage()
 			return
 		}
-		factory514 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt515 := factory514.GetProtocol(mbTrans512)
+		factory517 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt518 := factory517.GetProtocol(mbTrans515)
 		argvalue0 := aurora.NewTaskQuery()
-		err516 := argvalue0.Read(jsProt515)
-		if err516 != nil {
+		err519 := argvalue0.Read(jsProt518)
+		if err519 != nil {
 			Usage()
 			return
 		}
@@ -911,19 +913,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksWithoutConfigs requires 1 args")
 			flag.Usage()
 		}
-		arg517 := flag.Arg(1)
-		mbTrans518 := thrift.NewTMemoryBufferLen(len(arg517))
-		defer mbTrans518.Close()
-		_, err519 := mbTrans518.WriteString(arg517)
-		if err519 != nil {
+		arg520 := flag.Arg(1)
+		mbTrans521 := thrift.NewTMemoryBufferLen(len(arg520))
+		defer mbTrans521.Close()
+		_, err522 := mbTrans521.WriteString(arg520)
+		if err522 != nil {
 			Usage()
 			return
 		}
-		factory520 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt521 := factory520.GetProtocol(mbTrans518)
+		factory523 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt524 := factory523.GetProtocol(mbTrans521)
 		argvalue0 := aurora.NewTaskQuery()
-		err522 := argvalue0.Read(jsProt521)
-		if err522 != nil {
+		err525 := argvalue0.Read(jsProt524)
+		if err525 != nil {
 			Usage()
 			return
 		}
@@ -936,19 +938,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetPendingReason requires 1 args")
 			flag.Usage()
 		}
-		arg523 := flag.Arg(1)
-		mbTrans524 := thrift.NewTMemoryBufferLen(len(arg523))
-		defer mbTrans524.Close()
-		_, err525 := mbTrans524.WriteString(arg523)
-		if err525 != nil {
+		arg526 := flag.Arg(1)
+		mbTrans527 := thrift.NewTMemoryBufferLen(len(arg526))
+		defer mbTrans527.Close()
+		_, err528 := mbTrans527.WriteString(arg526)
+		if err528 != nil {
 			Usage()
 			return
 		}
-		factory526 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt527 := factory526.GetProtocol(mbTrans524)
+		factory529 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt530 := factory529.GetProtocol(mbTrans527)
 		argvalue0 := aurora.NewTaskQuery()
-		err528 := argvalue0.Read(jsProt527)
-		if err528 != nil {
+		err531 := argvalue0.Read(jsProt530)
+		if err531 != nil {
 			Usage()
 			return
 		}
@@ -961,19 +963,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetConfigSummary requires 1 args")
 			flag.Usage()
 		}
-		arg529 := flag.Arg(1)
-		mbTrans530 := thrift.NewTMemoryBufferLen(len(arg529))
-		defer mbTrans530.Close()
-		_, err531 := mbTrans530.WriteString(arg529)
-		if err531 != nil {
+		arg532 := flag.Arg(1)
+		mbTrans533 := thrift.NewTMemoryBufferLen(len(arg532))
+		defer mbTrans533.Close()
+		_, err534 := mbTrans533.WriteString(arg532)
+		if err534 != nil {
 			Usage()
 			return
 		}
-		factory532 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt533 := factory532.GetProtocol(mbTrans530)
+		factory535 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt536 := factory535.GetProtocol(mbTrans533)
 		argvalue0 := aurora.NewJobKey()
-		err534 := argvalue0.Read(jsProt533)
-		if err534 != nil {
+		err537 := argvalue0.Read(jsProt536)
+		if err537 != nil {
 			Usage()
 			return
 		}
@@ -1006,19 +1008,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PopulateJobConfig requires 1 args")
 			flag.Usage()
 		}
-		arg537 := flag.Arg(1)
-		mbTrans538 := thrift.NewTMemoryBufferLen(len(arg537))
-		defer mbTrans538.Close()
-		_, err539 := mbTrans538.WriteString(arg537)
-		if err539 != nil {
+		arg540 := flag.Arg(1)
+		mbTrans541 := thrift.NewTMemoryBufferLen(len(arg540))
+		defer mbTrans541.Close()
+		_, err542 := mbTrans541.WriteString(arg540)
+		if err542 != nil {
 			Usage()
 			return
 		}
-		factory540 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt541 := factory540.GetProtocol(mbTrans538)
+		factory543 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt544 := factory543.GetProtocol(mbTrans541)
 		argvalue0 := aurora.NewJobConfiguration()
-		err542 := argvalue0.Read(jsProt541)
-		if err542 != nil {
+		err545 := argvalue0.Read(jsProt544)
+		if err545 != nil {
 			Usage()
 			return
 		}
@@ -1031,19 +1033,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateSummaries requires 1 args")
 			flag.Usage()
 		}
-		arg543 := flag.Arg(1)
-		mbTrans544 := thrift.NewTMemoryBufferLen(len(arg543))
-		defer mbTrans544.Close()
-		_, err545 := mbTrans544.WriteString(arg543)
-		if err545 != nil {
+		arg546 := flag.Arg(1)
+		mbTrans547 := thrift.NewTMemoryBufferLen(len(arg546))
+		defer mbTrans547.Close()
+		_, err548 := mbTrans547.WriteString(arg546)
+		if err548 != nil {
 			Usage()
 			return
 		}
-		factory546 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt547 := factory546.GetProtocol(mbTrans544)
+		factory549 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt550 := factory549.GetProtocol(mbTrans547)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err548 := argvalue0.Read(jsProt547)
-		if err548 != nil {
+		err551 := argvalue0.Read(jsProt550)
+		if err551 != nil {
 			Usage()
 			return
 		}
@@ -1056,19 +1058,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDetails requires 1 args")
 			flag.Usage()
 		}
-		arg549 := flag.Arg(1)
-		mbTrans550 := thrift.NewTMemoryBufferLen(len(arg549))
-		defer mbTrans550.Close()
-		_, err551 := mbTrans550.WriteString(arg549)
-		if err551 != nil {
+		arg552 := flag.Arg(1)
+		mbTrans553 := thrift.NewTMemoryBufferLen(len(arg552))
+		defer mbTrans553.Close()
+		_, err554 := mbTrans553.WriteString(arg552)
+		if err554 != nil {
 			Usage()
 			return
 		}
-		factory552 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt553 := factory552.GetProtocol(mbTrans550)
+		factory555 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt556 := factory555.GetProtocol(mbTrans553)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err554 := argvalue0.Read(jsProt553)
-		if err554 != nil {
+		err557 := argvalue0.Read(jsProt556)
+		if err557 != nil {
 			Usage()
 			return
 		}
@@ -1081,19 +1083,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDiff requires 1 args")
 			flag.Usage()
 		}
-		arg555 := flag.Arg(1)
-		mbTrans556 := thrift.NewTMemoryBufferLen(len(arg555))
-		defer mbTrans556.Close()
-		_, err557 := mbTrans556.WriteString(arg555)
-		if err557 != nil {
+		arg558 := flag.Arg(1)
+		mbTrans559 := thrift.NewTMemoryBufferLen(len(arg558))
+		defer mbTrans559.Close()
+		_, err560 := mbTrans559.WriteString(arg558)
+		if err560 != nil {
 			Usage()
 			return
 		}
-		factory558 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt559 := factory558.GetProtocol(mbTrans556)
+		factory561 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt562 := factory561.GetProtocol(mbTrans559)
 		argvalue0 := aurora.NewJobUpdateRequest()
-		err560 := argvalue0.Read(jsProt559)
-		if err560 != nil {
+		err563 := argvalue0.Read(jsProt562)
+		if err563 != nil {
 			Usage()
 			return
 		}

--- a/gen-go/apache/aurora/aurora_scheduler_manager-remote/aurora_scheduler_manager-remote.go
+++ b/gen-go/apache/aurora/aurora_scheduler_manager-remote/aurora_scheduler_manager-remote.go
@@ -25,7 +25,7 @@ func Usage() {
 	fmt.Fprintln(os.Stderr, "  Response descheduleCronJob(JobKey job)")
 	fmt.Fprintln(os.Stderr, "  Response startCronJob(JobKey job)")
 	fmt.Fprintln(os.Stderr, "  Response restartShards(JobKey job,  shardIds)")
-	fmt.Fprintln(os.Stderr, "  Response killTasks(JobKey job,  instances)")
+	fmt.Fprintln(os.Stderr, "  Response killTasks(JobKey job,  instances, string message)")
 	fmt.Fprintln(os.Stderr, "  Response addInstances(InstanceKey key, i32 count)")
 	fmt.Fprintln(os.Stderr, "  Response replaceCronTemplate(JobConfiguration config)")
 	fmt.Fprintln(os.Stderr, "  Response startJobUpdate(JobUpdateRequest request, string message)")
@@ -146,19 +146,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "CreateJob requires 1 args")
 			flag.Usage()
 		}
-		arg163 := flag.Arg(1)
-		mbTrans164 := thrift.NewTMemoryBufferLen(len(arg163))
-		defer mbTrans164.Close()
-		_, err165 := mbTrans164.WriteString(arg163)
-		if err165 != nil {
+		arg164 := flag.Arg(1)
+		mbTrans165 := thrift.NewTMemoryBufferLen(len(arg164))
+		defer mbTrans165.Close()
+		_, err166 := mbTrans165.WriteString(arg164)
+		if err166 != nil {
 			Usage()
 			return
 		}
-		factory166 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt167 := factory166.GetProtocol(mbTrans164)
+		factory167 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt168 := factory167.GetProtocol(mbTrans165)
 		argvalue0 := aurora.NewJobConfiguration()
-		err168 := argvalue0.Read(jsProt167)
-		if err168 != nil {
+		err169 := argvalue0.Read(jsProt168)
+		if err169 != nil {
 			Usage()
 			return
 		}
@@ -171,19 +171,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ScheduleCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg169 := flag.Arg(1)
-		mbTrans170 := thrift.NewTMemoryBufferLen(len(arg169))
-		defer mbTrans170.Close()
-		_, err171 := mbTrans170.WriteString(arg169)
-		if err171 != nil {
+		arg170 := flag.Arg(1)
+		mbTrans171 := thrift.NewTMemoryBufferLen(len(arg170))
+		defer mbTrans171.Close()
+		_, err172 := mbTrans171.WriteString(arg170)
+		if err172 != nil {
 			Usage()
 			return
 		}
-		factory172 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt173 := factory172.GetProtocol(mbTrans170)
+		factory173 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt174 := factory173.GetProtocol(mbTrans171)
 		argvalue0 := aurora.NewJobConfiguration()
-		err174 := argvalue0.Read(jsProt173)
-		if err174 != nil {
+		err175 := argvalue0.Read(jsProt174)
+		if err175 != nil {
 			Usage()
 			return
 		}
@@ -196,19 +196,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "DescheduleCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg175 := flag.Arg(1)
-		mbTrans176 := thrift.NewTMemoryBufferLen(len(arg175))
-		defer mbTrans176.Close()
-		_, err177 := mbTrans176.WriteString(arg175)
-		if err177 != nil {
+		arg176 := flag.Arg(1)
+		mbTrans177 := thrift.NewTMemoryBufferLen(len(arg176))
+		defer mbTrans177.Close()
+		_, err178 := mbTrans177.WriteString(arg176)
+		if err178 != nil {
 			Usage()
 			return
 		}
-		factory178 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt179 := factory178.GetProtocol(mbTrans176)
+		factory179 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt180 := factory179.GetProtocol(mbTrans177)
 		argvalue0 := aurora.NewJobKey()
-		err180 := argvalue0.Read(jsProt179)
-		if err180 != nil {
+		err181 := argvalue0.Read(jsProt180)
+		if err181 != nil {
 			Usage()
 			return
 		}
@@ -221,19 +221,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartCronJob requires 1 args")
 			flag.Usage()
 		}
-		arg181 := flag.Arg(1)
-		mbTrans182 := thrift.NewTMemoryBufferLen(len(arg181))
-		defer mbTrans182.Close()
-		_, err183 := mbTrans182.WriteString(arg181)
-		if err183 != nil {
+		arg182 := flag.Arg(1)
+		mbTrans183 := thrift.NewTMemoryBufferLen(len(arg182))
+		defer mbTrans183.Close()
+		_, err184 := mbTrans183.WriteString(arg182)
+		if err184 != nil {
 			Usage()
 			return
 		}
-		factory184 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt185 := factory184.GetProtocol(mbTrans182)
+		factory185 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt186 := factory185.GetProtocol(mbTrans183)
 		argvalue0 := aurora.NewJobKey()
-		err186 := argvalue0.Read(jsProt185)
-		if err186 != nil {
+		err187 := argvalue0.Read(jsProt186)
+		if err187 != nil {
 			Usage()
 			return
 		}
@@ -246,36 +246,36 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RestartShards requires 2 args")
 			flag.Usage()
 		}
-		arg187 := flag.Arg(1)
-		mbTrans188 := thrift.NewTMemoryBufferLen(len(arg187))
-		defer mbTrans188.Close()
-		_, err189 := mbTrans188.WriteString(arg187)
-		if err189 != nil {
+		arg188 := flag.Arg(1)
+		mbTrans189 := thrift.NewTMemoryBufferLen(len(arg188))
+		defer mbTrans189.Close()
+		_, err190 := mbTrans189.WriteString(arg188)
+		if err190 != nil {
 			Usage()
 			return
 		}
-		factory190 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt191 := factory190.GetProtocol(mbTrans188)
+		factory191 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt192 := factory191.GetProtocol(mbTrans189)
 		argvalue0 := aurora.NewJobKey()
-		err192 := argvalue0.Read(jsProt191)
-		if err192 != nil {
+		err193 := argvalue0.Read(jsProt192)
+		if err193 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
-		arg193 := flag.Arg(2)
-		mbTrans194 := thrift.NewTMemoryBufferLen(len(arg193))
-		defer mbTrans194.Close()
-		_, err195 := mbTrans194.WriteString(arg193)
-		if err195 != nil {
+		arg194 := flag.Arg(2)
+		mbTrans195 := thrift.NewTMemoryBufferLen(len(arg194))
+		defer mbTrans195.Close()
+		_, err196 := mbTrans195.WriteString(arg194)
+		if err196 != nil {
 			Usage()
 			return
 		}
-		factory196 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt197 := factory196.GetProtocol(mbTrans194)
+		factory197 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt198 := factory197.GetProtocol(mbTrans195)
 		containerStruct1 := aurora.NewAuroraSchedulerManagerRestartShardsArgs()
-		err198 := containerStruct1.ReadField2(jsProt197)
-		if err198 != nil {
+		err199 := containerStruct1.ReadField2(jsProt198)
+		if err199 != nil {
 			Usage()
 			return
 		}
@@ -285,46 +285,48 @@ func main() {
 		fmt.Print("\n")
 		break
 	case "killTasks":
-		if flag.NArg()-1 != 2 {
-			fmt.Fprintln(os.Stderr, "KillTasks requires 2 args")
+		if flag.NArg()-1 != 3 {
+			fmt.Fprintln(os.Stderr, "KillTasks requires 3 args")
 			flag.Usage()
 		}
-		arg199 := flag.Arg(1)
-		mbTrans200 := thrift.NewTMemoryBufferLen(len(arg199))
-		defer mbTrans200.Close()
-		_, err201 := mbTrans200.WriteString(arg199)
-		if err201 != nil {
+		arg200 := flag.Arg(1)
+		mbTrans201 := thrift.NewTMemoryBufferLen(len(arg200))
+		defer mbTrans201.Close()
+		_, err202 := mbTrans201.WriteString(arg200)
+		if err202 != nil {
 			Usage()
 			return
 		}
-		factory202 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt203 := factory202.GetProtocol(mbTrans200)
+		factory203 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt204 := factory203.GetProtocol(mbTrans201)
 		argvalue0 := aurora.NewJobKey()
-		err204 := argvalue0.Read(jsProt203)
-		if err204 != nil {
+		err205 := argvalue0.Read(jsProt204)
+		if err205 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
-		arg205 := flag.Arg(2)
-		mbTrans206 := thrift.NewTMemoryBufferLen(len(arg205))
-		defer mbTrans206.Close()
-		_, err207 := mbTrans206.WriteString(arg205)
-		if err207 != nil {
+		arg206 := flag.Arg(2)
+		mbTrans207 := thrift.NewTMemoryBufferLen(len(arg206))
+		defer mbTrans207.Close()
+		_, err208 := mbTrans207.WriteString(arg206)
+		if err208 != nil {
 			Usage()
 			return
 		}
-		factory208 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt209 := factory208.GetProtocol(mbTrans206)
+		factory209 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt210 := factory209.GetProtocol(mbTrans207)
 		containerStruct1 := aurora.NewAuroraSchedulerManagerKillTasksArgs()
-		err210 := containerStruct1.ReadField2(jsProt209)
-		if err210 != nil {
+		err211 := containerStruct1.ReadField2(jsProt210)
+		if err211 != nil {
 			Usage()
 			return
 		}
 		argvalue1 := containerStruct1.Instances
 		value1 := argvalue1
-		fmt.Print(client.KillTasks(value0, value1))
+		argvalue2 := flag.Arg(3)
+		value2 := argvalue2
+		fmt.Print(client.KillTasks(value0, value1, value2))
 		fmt.Print("\n")
 		break
 	case "addInstances":
@@ -332,25 +334,25 @@ func main() {
 			fmt.Fprintln(os.Stderr, "AddInstances requires 2 args")
 			flag.Usage()
 		}
-		arg211 := flag.Arg(1)
-		mbTrans212 := thrift.NewTMemoryBufferLen(len(arg211))
-		defer mbTrans212.Close()
-		_, err213 := mbTrans212.WriteString(arg211)
-		if err213 != nil {
+		arg213 := flag.Arg(1)
+		mbTrans214 := thrift.NewTMemoryBufferLen(len(arg213))
+		defer mbTrans214.Close()
+		_, err215 := mbTrans214.WriteString(arg213)
+		if err215 != nil {
 			Usage()
 			return
 		}
-		factory214 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt215 := factory214.GetProtocol(mbTrans212)
+		factory216 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt217 := factory216.GetProtocol(mbTrans214)
 		argvalue0 := aurora.NewInstanceKey()
-		err216 := argvalue0.Read(jsProt215)
-		if err216 != nil {
+		err218 := argvalue0.Read(jsProt217)
+		if err218 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
-		tmp1, err217 := (strconv.Atoi(flag.Arg(2)))
-		if err217 != nil {
+		tmp1, err219 := (strconv.Atoi(flag.Arg(2)))
+		if err219 != nil {
 			Usage()
 			return
 		}
@@ -364,19 +366,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ReplaceCronTemplate requires 1 args")
 			flag.Usage()
 		}
-		arg218 := flag.Arg(1)
-		mbTrans219 := thrift.NewTMemoryBufferLen(len(arg218))
-		defer mbTrans219.Close()
-		_, err220 := mbTrans219.WriteString(arg218)
-		if err220 != nil {
+		arg220 := flag.Arg(1)
+		mbTrans221 := thrift.NewTMemoryBufferLen(len(arg220))
+		defer mbTrans221.Close()
+		_, err222 := mbTrans221.WriteString(arg220)
+		if err222 != nil {
 			Usage()
 			return
 		}
-		factory221 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt222 := factory221.GetProtocol(mbTrans219)
+		factory223 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt224 := factory223.GetProtocol(mbTrans221)
 		argvalue0 := aurora.NewJobConfiguration()
-		err223 := argvalue0.Read(jsProt222)
-		if err223 != nil {
+		err225 := argvalue0.Read(jsProt224)
+		if err225 != nil {
 			Usage()
 			return
 		}
@@ -389,19 +391,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg224 := flag.Arg(1)
-		mbTrans225 := thrift.NewTMemoryBufferLen(len(arg224))
-		defer mbTrans225.Close()
-		_, err226 := mbTrans225.WriteString(arg224)
-		if err226 != nil {
+		arg226 := flag.Arg(1)
+		mbTrans227 := thrift.NewTMemoryBufferLen(len(arg226))
+		defer mbTrans227.Close()
+		_, err228 := mbTrans227.WriteString(arg226)
+		if err228 != nil {
 			Usage()
 			return
 		}
-		factory227 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt228 := factory227.GetProtocol(mbTrans225)
+		factory229 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt230 := factory229.GetProtocol(mbTrans227)
 		argvalue0 := aurora.NewJobUpdateRequest()
-		err229 := argvalue0.Read(jsProt228)
-		if err229 != nil {
+		err231 := argvalue0.Read(jsProt230)
+		if err231 != nil {
 			Usage()
 			return
 		}
@@ -416,19 +418,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PauseJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg231 := flag.Arg(1)
-		mbTrans232 := thrift.NewTMemoryBufferLen(len(arg231))
-		defer mbTrans232.Close()
-		_, err233 := mbTrans232.WriteString(arg231)
-		if err233 != nil {
+		arg233 := flag.Arg(1)
+		mbTrans234 := thrift.NewTMemoryBufferLen(len(arg233))
+		defer mbTrans234.Close()
+		_, err235 := mbTrans234.WriteString(arg233)
+		if err235 != nil {
 			Usage()
 			return
 		}
-		factory234 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt235 := factory234.GetProtocol(mbTrans232)
+		factory236 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt237 := factory236.GetProtocol(mbTrans234)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err236 := argvalue0.Read(jsProt235)
-		if err236 != nil {
+		err238 := argvalue0.Read(jsProt237)
+		if err238 != nil {
 			Usage()
 			return
 		}
@@ -443,19 +445,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "ResumeJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg238 := flag.Arg(1)
-		mbTrans239 := thrift.NewTMemoryBufferLen(len(arg238))
-		defer mbTrans239.Close()
-		_, err240 := mbTrans239.WriteString(arg238)
-		if err240 != nil {
+		arg240 := flag.Arg(1)
+		mbTrans241 := thrift.NewTMemoryBufferLen(len(arg240))
+		defer mbTrans241.Close()
+		_, err242 := mbTrans241.WriteString(arg240)
+		if err242 != nil {
 			Usage()
 			return
 		}
-		factory241 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt242 := factory241.GetProtocol(mbTrans239)
+		factory243 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt244 := factory243.GetProtocol(mbTrans241)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err243 := argvalue0.Read(jsProt242)
-		if err243 != nil {
+		err245 := argvalue0.Read(jsProt244)
+		if err245 != nil {
 			Usage()
 			return
 		}
@@ -470,19 +472,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "AbortJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg245 := flag.Arg(1)
-		mbTrans246 := thrift.NewTMemoryBufferLen(len(arg245))
-		defer mbTrans246.Close()
-		_, err247 := mbTrans246.WriteString(arg245)
-		if err247 != nil {
+		arg247 := flag.Arg(1)
+		mbTrans248 := thrift.NewTMemoryBufferLen(len(arg247))
+		defer mbTrans248.Close()
+		_, err249 := mbTrans248.WriteString(arg247)
+		if err249 != nil {
 			Usage()
 			return
 		}
-		factory248 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt249 := factory248.GetProtocol(mbTrans246)
+		factory250 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt251 := factory250.GetProtocol(mbTrans248)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err250 := argvalue0.Read(jsProt249)
-		if err250 != nil {
+		err252 := argvalue0.Read(jsProt251)
+		if err252 != nil {
 			Usage()
 			return
 		}
@@ -497,19 +499,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RollbackJobUpdate requires 2 args")
 			flag.Usage()
 		}
-		arg252 := flag.Arg(1)
-		mbTrans253 := thrift.NewTMemoryBufferLen(len(arg252))
-		defer mbTrans253.Close()
-		_, err254 := mbTrans253.WriteString(arg252)
-		if err254 != nil {
+		arg254 := flag.Arg(1)
+		mbTrans255 := thrift.NewTMemoryBufferLen(len(arg254))
+		defer mbTrans255.Close()
+		_, err256 := mbTrans255.WriteString(arg254)
+		if err256 != nil {
 			Usage()
 			return
 		}
-		factory255 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt256 := factory255.GetProtocol(mbTrans253)
+		factory257 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt258 := factory257.GetProtocol(mbTrans255)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err257 := argvalue0.Read(jsProt256)
-		if err257 != nil {
+		err259 := argvalue0.Read(jsProt258)
+		if err259 != nil {
 			Usage()
 			return
 		}
@@ -524,19 +526,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PulseJobUpdate requires 1 args")
 			flag.Usage()
 		}
-		arg259 := flag.Arg(1)
-		mbTrans260 := thrift.NewTMemoryBufferLen(len(arg259))
-		defer mbTrans260.Close()
-		_, err261 := mbTrans260.WriteString(arg259)
-		if err261 != nil {
+		arg261 := flag.Arg(1)
+		mbTrans262 := thrift.NewTMemoryBufferLen(len(arg261))
+		defer mbTrans262.Close()
+		_, err263 := mbTrans262.WriteString(arg261)
+		if err263 != nil {
 			Usage()
 			return
 		}
-		factory262 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt263 := factory262.GetProtocol(mbTrans260)
+		factory264 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt265 := factory264.GetProtocol(mbTrans262)
 		argvalue0 := aurora.NewJobUpdateKey()
-		err264 := argvalue0.Read(jsProt263)
-		if err264 != nil {
+		err266 := argvalue0.Read(jsProt265)
+		if err266 != nil {
 			Usage()
 			return
 		}
@@ -567,19 +569,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksStatus requires 1 args")
 			flag.Usage()
 		}
-		arg266 := flag.Arg(1)
-		mbTrans267 := thrift.NewTMemoryBufferLen(len(arg266))
-		defer mbTrans267.Close()
-		_, err268 := mbTrans267.WriteString(arg266)
-		if err268 != nil {
+		arg268 := flag.Arg(1)
+		mbTrans269 := thrift.NewTMemoryBufferLen(len(arg268))
+		defer mbTrans269.Close()
+		_, err270 := mbTrans269.WriteString(arg268)
+		if err270 != nil {
 			Usage()
 			return
 		}
-		factory269 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt270 := factory269.GetProtocol(mbTrans267)
+		factory271 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt272 := factory271.GetProtocol(mbTrans269)
 		argvalue0 := aurora.NewTaskQuery()
-		err271 := argvalue0.Read(jsProt270)
-		if err271 != nil {
+		err273 := argvalue0.Read(jsProt272)
+		if err273 != nil {
 			Usage()
 			return
 		}
@@ -592,19 +594,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksWithoutConfigs requires 1 args")
 			flag.Usage()
 		}
-		arg272 := flag.Arg(1)
-		mbTrans273 := thrift.NewTMemoryBufferLen(len(arg272))
-		defer mbTrans273.Close()
-		_, err274 := mbTrans273.WriteString(arg272)
-		if err274 != nil {
+		arg274 := flag.Arg(1)
+		mbTrans275 := thrift.NewTMemoryBufferLen(len(arg274))
+		defer mbTrans275.Close()
+		_, err276 := mbTrans275.WriteString(arg274)
+		if err276 != nil {
 			Usage()
 			return
 		}
-		factory275 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt276 := factory275.GetProtocol(mbTrans273)
+		factory277 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt278 := factory277.GetProtocol(mbTrans275)
 		argvalue0 := aurora.NewTaskQuery()
-		err277 := argvalue0.Read(jsProt276)
-		if err277 != nil {
+		err279 := argvalue0.Read(jsProt278)
+		if err279 != nil {
 			Usage()
 			return
 		}
@@ -617,19 +619,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetPendingReason requires 1 args")
 			flag.Usage()
 		}
-		arg278 := flag.Arg(1)
-		mbTrans279 := thrift.NewTMemoryBufferLen(len(arg278))
-		defer mbTrans279.Close()
-		_, err280 := mbTrans279.WriteString(arg278)
-		if err280 != nil {
+		arg280 := flag.Arg(1)
+		mbTrans281 := thrift.NewTMemoryBufferLen(len(arg280))
+		defer mbTrans281.Close()
+		_, err282 := mbTrans281.WriteString(arg280)
+		if err282 != nil {
 			Usage()
 			return
 		}
-		factory281 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt282 := factory281.GetProtocol(mbTrans279)
+		factory283 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt284 := factory283.GetProtocol(mbTrans281)
 		argvalue0 := aurora.NewTaskQuery()
-		err283 := argvalue0.Read(jsProt282)
-		if err283 != nil {
+		err285 := argvalue0.Read(jsProt284)
+		if err285 != nil {
 			Usage()
 			return
 		}
@@ -642,19 +644,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetConfigSummary requires 1 args")
 			flag.Usage()
 		}
-		arg284 := flag.Arg(1)
-		mbTrans285 := thrift.NewTMemoryBufferLen(len(arg284))
-		defer mbTrans285.Close()
-		_, err286 := mbTrans285.WriteString(arg284)
-		if err286 != nil {
+		arg286 := flag.Arg(1)
+		mbTrans287 := thrift.NewTMemoryBufferLen(len(arg286))
+		defer mbTrans287.Close()
+		_, err288 := mbTrans287.WriteString(arg286)
+		if err288 != nil {
 			Usage()
 			return
 		}
-		factory287 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt288 := factory287.GetProtocol(mbTrans285)
+		factory289 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt290 := factory289.GetProtocol(mbTrans287)
 		argvalue0 := aurora.NewJobKey()
-		err289 := argvalue0.Read(jsProt288)
-		if err289 != nil {
+		err291 := argvalue0.Read(jsProt290)
+		if err291 != nil {
 			Usage()
 			return
 		}
@@ -687,19 +689,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PopulateJobConfig requires 1 args")
 			flag.Usage()
 		}
-		arg292 := flag.Arg(1)
-		mbTrans293 := thrift.NewTMemoryBufferLen(len(arg292))
-		defer mbTrans293.Close()
-		_, err294 := mbTrans293.WriteString(arg292)
-		if err294 != nil {
+		arg294 := flag.Arg(1)
+		mbTrans295 := thrift.NewTMemoryBufferLen(len(arg294))
+		defer mbTrans295.Close()
+		_, err296 := mbTrans295.WriteString(arg294)
+		if err296 != nil {
 			Usage()
 			return
 		}
-		factory295 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt296 := factory295.GetProtocol(mbTrans293)
+		factory297 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt298 := factory297.GetProtocol(mbTrans295)
 		argvalue0 := aurora.NewJobConfiguration()
-		err297 := argvalue0.Read(jsProt296)
-		if err297 != nil {
+		err299 := argvalue0.Read(jsProt298)
+		if err299 != nil {
 			Usage()
 			return
 		}
@@ -712,19 +714,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateSummaries requires 1 args")
 			flag.Usage()
 		}
-		arg298 := flag.Arg(1)
-		mbTrans299 := thrift.NewTMemoryBufferLen(len(arg298))
-		defer mbTrans299.Close()
-		_, err300 := mbTrans299.WriteString(arg298)
-		if err300 != nil {
+		arg300 := flag.Arg(1)
+		mbTrans301 := thrift.NewTMemoryBufferLen(len(arg300))
+		defer mbTrans301.Close()
+		_, err302 := mbTrans301.WriteString(arg300)
+		if err302 != nil {
 			Usage()
 			return
 		}
-		factory301 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt302 := factory301.GetProtocol(mbTrans299)
+		factory303 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt304 := factory303.GetProtocol(mbTrans301)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err303 := argvalue0.Read(jsProt302)
-		if err303 != nil {
+		err305 := argvalue0.Read(jsProt304)
+		if err305 != nil {
 			Usage()
 			return
 		}
@@ -737,19 +739,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDetails requires 1 args")
 			flag.Usage()
 		}
-		arg304 := flag.Arg(1)
-		mbTrans305 := thrift.NewTMemoryBufferLen(len(arg304))
-		defer mbTrans305.Close()
-		_, err306 := mbTrans305.WriteString(arg304)
-		if err306 != nil {
+		arg306 := flag.Arg(1)
+		mbTrans307 := thrift.NewTMemoryBufferLen(len(arg306))
+		defer mbTrans307.Close()
+		_, err308 := mbTrans307.WriteString(arg306)
+		if err308 != nil {
 			Usage()
 			return
 		}
-		factory307 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt308 := factory307.GetProtocol(mbTrans305)
+		factory309 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt310 := factory309.GetProtocol(mbTrans307)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err309 := argvalue0.Read(jsProt308)
-		if err309 != nil {
+		err311 := argvalue0.Read(jsProt310)
+		if err311 != nil {
 			Usage()
 			return
 		}
@@ -762,19 +764,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDiff requires 1 args")
 			flag.Usage()
 		}
-		arg310 := flag.Arg(1)
-		mbTrans311 := thrift.NewTMemoryBufferLen(len(arg310))
-		defer mbTrans311.Close()
-		_, err312 := mbTrans311.WriteString(arg310)
-		if err312 != nil {
+		arg312 := flag.Arg(1)
+		mbTrans313 := thrift.NewTMemoryBufferLen(len(arg312))
+		defer mbTrans313.Close()
+		_, err314 := mbTrans313.WriteString(arg312)
+		if err314 != nil {
 			Usage()
 			return
 		}
-		factory313 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt314 := factory313.GetProtocol(mbTrans311)
+		factory315 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt316 := factory315.GetProtocol(mbTrans313)
 		argvalue0 := aurora.NewJobUpdateRequest()
-		err315 := argvalue0.Read(jsProt314)
-		if err315 != nil {
+		err317 := argvalue0.Read(jsProt316)
+		if err317 != nil {
 			Usage()
 			return
 		}

--- a/gen-go/apache/aurora/auroraadmin.go
+++ b/gen-go/apache/aurora/auroraadmin.go
@@ -160,16 +160,16 @@ func (p *AuroraAdminClient) recvSetQuota() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error316 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error317 error
-		error317, err = error316.Read(iprot)
+		error318 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error319 error
+		error319, err = error318.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error317
+		err = error319
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -243,16 +243,16 @@ func (p *AuroraAdminClient) recvForceTaskState() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error318 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error319 error
-		error319, err = error318.Read(iprot)
+		error320 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error321 error
+		error321, err = error320.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error319
+		err = error321
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -317,16 +317,16 @@ func (p *AuroraAdminClient) recvPerformBackup() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error320 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error321 error
-		error321, err = error320.Read(iprot)
+		error322 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error323 error
+		error323, err = error322.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error321
+		err = error323
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -391,16 +391,16 @@ func (p *AuroraAdminClient) recvListBackups() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error322 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error323 error
-		error323, err = error322.Read(iprot)
+		error324 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error325 error
+		error325, err = error324.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error323
+		err = error325
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -470,16 +470,16 @@ func (p *AuroraAdminClient) recvStageRecovery() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error324 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error325 error
-		error325, err = error324.Read(iprot)
+		error326 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error327 error
+		error327, err = error326.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error325
+		err = error327
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -549,16 +549,16 @@ func (p *AuroraAdminClient) recvQueryRecovery() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error326 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error327 error
-		error327, err = error326.Read(iprot)
+		error328 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error329 error
+		error329, err = error328.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error327
+		err = error329
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -628,16 +628,16 @@ func (p *AuroraAdminClient) recvDeleteRecoveryTasks() (value *Response, err erro
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error328 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error329 error
-		error329, err = error328.Read(iprot)
+		error330 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error331 error
+		error331, err = error330.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error329
+		err = error331
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -702,16 +702,16 @@ func (p *AuroraAdminClient) recvCommitRecovery() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error330 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error331 error
-		error331, err = error330.Read(iprot)
+		error332 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error333 error
+		error333, err = error332.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error331
+		err = error333
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -776,16 +776,16 @@ func (p *AuroraAdminClient) recvUnloadRecovery() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error332 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error333 error
-		error333, err = error332.Read(iprot)
+		error334 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error335 error
+		error335, err = error334.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error333
+		err = error335
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -855,16 +855,16 @@ func (p *AuroraAdminClient) recvStartMaintenance() (value *Response, err error) 
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error334 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error335 error
-		error335, err = error334.Read(iprot)
+		error336 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error337 error
+		error337, err = error336.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error335
+		err = error337
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -934,16 +934,16 @@ func (p *AuroraAdminClient) recvDrainHosts() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error336 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error337 error
-		error337, err = error336.Read(iprot)
+		error338 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error339 error
+		error339, err = error338.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error337
+		err = error339
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1013,16 +1013,16 @@ func (p *AuroraAdminClient) recvMaintenanceStatus() (value *Response, err error)
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error338 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error339 error
-		error339, err = error338.Read(iprot)
+		error340 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error341 error
+		error341, err = error340.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error339
+		err = error341
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1092,16 +1092,16 @@ func (p *AuroraAdminClient) recvEndMaintenance() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error340 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error341 error
-		error341, err = error340.Read(iprot)
+		error342 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error343 error
+		error343, err = error342.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error341
+		err = error343
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1166,16 +1166,16 @@ func (p *AuroraAdminClient) recvSnapshot() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error342 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error343 error
-		error343, err = error342.Read(iprot)
+		error344 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error345 error
+		error345, err = error344.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error343
+		err = error345
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1249,16 +1249,16 @@ func (p *AuroraAdminClient) recvRewriteConfigs() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error344 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error345 error
-		error345, err = error344.Read(iprot)
+		error346 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error347 error
+		error347, err = error346.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error345
+		err = error347
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1328,16 +1328,16 @@ func (p *AuroraAdminClient) recvTriggerExplicitTaskReconciliation() (value *Resp
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error346 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error347 error
-		error347, err = error346.Read(iprot)
+		error348 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error349 error
+		error349, err = error348.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error347
+		err = error349
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1402,16 +1402,16 @@ func (p *AuroraAdminClient) recvTriggerImplicitTaskReconciliation() (value *Resp
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error348 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error349 error
-		error349, err = error348.Read(iprot)
+		error350 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error351 error
+		error351, err = error350.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error349
+		err = error351
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1434,25 +1434,25 @@ type AuroraAdminProcessor struct {
 }
 
 func NewAuroraAdminProcessor(handler AuroraAdmin) *AuroraAdminProcessor {
-	self350 := &AuroraAdminProcessor{NewAuroraSchedulerManagerProcessor(handler)}
-	self350.AddToProcessorMap("setQuota", &auroraAdminProcessorSetQuota{handler: handler})
-	self350.AddToProcessorMap("forceTaskState", &auroraAdminProcessorForceTaskState{handler: handler})
-	self350.AddToProcessorMap("performBackup", &auroraAdminProcessorPerformBackup{handler: handler})
-	self350.AddToProcessorMap("listBackups", &auroraAdminProcessorListBackups{handler: handler})
-	self350.AddToProcessorMap("stageRecovery", &auroraAdminProcessorStageRecovery{handler: handler})
-	self350.AddToProcessorMap("queryRecovery", &auroraAdminProcessorQueryRecovery{handler: handler})
-	self350.AddToProcessorMap("deleteRecoveryTasks", &auroraAdminProcessorDeleteRecoveryTasks{handler: handler})
-	self350.AddToProcessorMap("commitRecovery", &auroraAdminProcessorCommitRecovery{handler: handler})
-	self350.AddToProcessorMap("unloadRecovery", &auroraAdminProcessorUnloadRecovery{handler: handler})
-	self350.AddToProcessorMap("startMaintenance", &auroraAdminProcessorStartMaintenance{handler: handler})
-	self350.AddToProcessorMap("drainHosts", &auroraAdminProcessorDrainHosts{handler: handler})
-	self350.AddToProcessorMap("maintenanceStatus", &auroraAdminProcessorMaintenanceStatus{handler: handler})
-	self350.AddToProcessorMap("endMaintenance", &auroraAdminProcessorEndMaintenance{handler: handler})
-	self350.AddToProcessorMap("snapshot", &auroraAdminProcessorSnapshot{handler: handler})
-	self350.AddToProcessorMap("rewriteConfigs", &auroraAdminProcessorRewriteConfigs{handler: handler})
-	self350.AddToProcessorMap("triggerExplicitTaskReconciliation", &auroraAdminProcessorTriggerExplicitTaskReconciliation{handler: handler})
-	self350.AddToProcessorMap("triggerImplicitTaskReconciliation", &auroraAdminProcessorTriggerImplicitTaskReconciliation{handler: handler})
-	return self350
+	self352 := &AuroraAdminProcessor{NewAuroraSchedulerManagerProcessor(handler)}
+	self352.AddToProcessorMap("setQuota", &auroraAdminProcessorSetQuota{handler: handler})
+	self352.AddToProcessorMap("forceTaskState", &auroraAdminProcessorForceTaskState{handler: handler})
+	self352.AddToProcessorMap("performBackup", &auroraAdminProcessorPerformBackup{handler: handler})
+	self352.AddToProcessorMap("listBackups", &auroraAdminProcessorListBackups{handler: handler})
+	self352.AddToProcessorMap("stageRecovery", &auroraAdminProcessorStageRecovery{handler: handler})
+	self352.AddToProcessorMap("queryRecovery", &auroraAdminProcessorQueryRecovery{handler: handler})
+	self352.AddToProcessorMap("deleteRecoveryTasks", &auroraAdminProcessorDeleteRecoveryTasks{handler: handler})
+	self352.AddToProcessorMap("commitRecovery", &auroraAdminProcessorCommitRecovery{handler: handler})
+	self352.AddToProcessorMap("unloadRecovery", &auroraAdminProcessorUnloadRecovery{handler: handler})
+	self352.AddToProcessorMap("startMaintenance", &auroraAdminProcessorStartMaintenance{handler: handler})
+	self352.AddToProcessorMap("drainHosts", &auroraAdminProcessorDrainHosts{handler: handler})
+	self352.AddToProcessorMap("maintenanceStatus", &auroraAdminProcessorMaintenanceStatus{handler: handler})
+	self352.AddToProcessorMap("endMaintenance", &auroraAdminProcessorEndMaintenance{handler: handler})
+	self352.AddToProcessorMap("snapshot", &auroraAdminProcessorSnapshot{handler: handler})
+	self352.AddToProcessorMap("rewriteConfigs", &auroraAdminProcessorRewriteConfigs{handler: handler})
+	self352.AddToProcessorMap("triggerExplicitTaskReconciliation", &auroraAdminProcessorTriggerExplicitTaskReconciliation{handler: handler})
+	self352.AddToProcessorMap("triggerImplicitTaskReconciliation", &auroraAdminProcessorTriggerImplicitTaskReconciliation{handler: handler})
+	return self352
 }
 
 type auroraAdminProcessorSetQuota struct {

--- a/gen-go/apache/aurora/auroraschedulermanager.go
+++ b/gen-go/apache/aurora/auroraschedulermanager.go
@@ -53,7 +53,8 @@ type AuroraSchedulerManager interface {
 	// Parameters:
 	//  - Job
 	//  - Instances
-	KillTasks(job *JobKey, instances map[int32]bool) (r *Response, err error)
+	//  - Message
+	KillTasks(job *JobKey, instances map[int32]bool, message string) (r *Response, err error)
 	// Adds new instances with the TaskConfig of the existing instance pointed by the key.
 	//
 	// Parameters:
@@ -170,16 +171,16 @@ func (p *AuroraSchedulerManagerClient) recvCreateJob() (value *Response, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error132 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error133 error
-		error133, err = error132.Read(iprot)
+		error133 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error134 error
+		error134, err = error133.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error133
+		err = error134
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -251,16 +252,16 @@ func (p *AuroraSchedulerManagerClient) recvScheduleCronJob() (value *Response, e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error134 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error135 error
-		error135, err = error134.Read(iprot)
+		error135 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error136 error
+		error136, err = error135.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error135
+		err = error136
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -331,16 +332,16 @@ func (p *AuroraSchedulerManagerClient) recvDescheduleCronJob() (value *Response,
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error136 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error137 error
-		error137, err = error136.Read(iprot)
+		error137 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error138 error
+		error138, err = error137.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error137
+		err = error138
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -411,16 +412,16 @@ func (p *AuroraSchedulerManagerClient) recvStartCronJob() (value *Response, err 
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error138 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error139 error
-		error139, err = error138.Read(iprot)
+		error139 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error140 error
+		error140, err = error139.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error139
+		err = error140
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -492,16 +493,16 @@ func (p *AuroraSchedulerManagerClient) recvRestartShards() (value *Response, err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error140 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error141 error
-		error141, err = error140.Read(iprot)
+		error141 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error142 error
+		error142, err = error141.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error141
+		err = error142
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -524,14 +525,15 @@ func (p *AuroraSchedulerManagerClient) recvRestartShards() (value *Response, err
 // Parameters:
 //  - Job
 //  - Instances
-func (p *AuroraSchedulerManagerClient) KillTasks(job *JobKey, instances map[int32]bool) (r *Response, err error) {
-	if err = p.sendKillTasks(job, instances); err != nil {
+//  - Message
+func (p *AuroraSchedulerManagerClient) KillTasks(job *JobKey, instances map[int32]bool, message string) (r *Response, err error) {
+	if err = p.sendKillTasks(job, instances, message); err != nil {
 		return
 	}
 	return p.recvKillTasks()
 }
 
-func (p *AuroraSchedulerManagerClient) sendKillTasks(job *JobKey, instances map[int32]bool) (err error) {
+func (p *AuroraSchedulerManagerClient) sendKillTasks(job *JobKey, instances map[int32]bool, message string) (err error) {
 	oprot := p.OutputProtocol
 	if oprot == nil {
 		oprot = p.ProtocolFactory.GetProtocol(p.Transport)
@@ -544,6 +546,7 @@ func (p *AuroraSchedulerManagerClient) sendKillTasks(job *JobKey, instances map[
 	args := AuroraSchedulerManagerKillTasksArgs{
 		Job:       job,
 		Instances: instances,
+		Message:   message,
 	}
 	if err = args.Write(oprot); err != nil {
 		return
@@ -573,16 +576,16 @@ func (p *AuroraSchedulerManagerClient) recvKillTasks() (value *Response, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error142 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error143 error
-		error143, err = error142.Read(iprot)
+		error143 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error144 error
+		error144, err = error143.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error143
+		err = error144
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -654,16 +657,16 @@ func (p *AuroraSchedulerManagerClient) recvAddInstances() (value *Response, err 
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error144 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error145 error
-		error145, err = error144.Read(iprot)
+		error145 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error146 error
+		error146, err = error145.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error145
+		err = error146
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -734,16 +737,16 @@ func (p *AuroraSchedulerManagerClient) recvReplaceCronTemplate() (value *Respons
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error146 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error147 error
-		error147, err = error146.Read(iprot)
+		error147 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error148 error
+		error148, err = error147.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error147
+		err = error148
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -815,16 +818,16 @@ func (p *AuroraSchedulerManagerClient) recvStartJobUpdate() (value *Response, er
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error148 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error149 error
-		error149, err = error148.Read(iprot)
+		error149 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error150 error
+		error150, err = error149.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error149
+		err = error150
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -896,16 +899,16 @@ func (p *AuroraSchedulerManagerClient) recvPauseJobUpdate() (value *Response, er
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error150 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error151 error
-		error151, err = error150.Read(iprot)
+		error151 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error152 error
+		error152, err = error151.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error151
+		err = error152
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -977,16 +980,16 @@ func (p *AuroraSchedulerManagerClient) recvResumeJobUpdate() (value *Response, e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error152 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error153 error
-		error153, err = error152.Read(iprot)
+		error153 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error154 error
+		error154, err = error153.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error153
+		err = error154
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1058,16 +1061,16 @@ func (p *AuroraSchedulerManagerClient) recvAbortJobUpdate() (value *Response, er
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error154 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error155 error
-		error155, err = error154.Read(iprot)
+		error155 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error156 error
+		error156, err = error155.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error155
+		err = error156
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1139,16 +1142,16 @@ func (p *AuroraSchedulerManagerClient) recvRollbackJobUpdate() (value *Response,
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error156 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error157 error
-		error157, err = error156.Read(iprot)
+		error157 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error158 error
+		error158, err = error157.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error157
+		err = error158
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1220,16 +1223,16 @@ func (p *AuroraSchedulerManagerClient) recvPulseJobUpdate() (value *Response, er
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error158 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error159 error
-		error159, err = error158.Read(iprot)
+		error159 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error160 error
+		error160, err = error159.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error159
+		err = error160
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1252,22 +1255,22 @@ type AuroraSchedulerManagerProcessor struct {
 }
 
 func NewAuroraSchedulerManagerProcessor(handler AuroraSchedulerManager) *AuroraSchedulerManagerProcessor {
-	self160 := &AuroraSchedulerManagerProcessor{NewReadOnlySchedulerProcessor(handler)}
-	self160.AddToProcessorMap("createJob", &auroraSchedulerManagerProcessorCreateJob{handler: handler})
-	self160.AddToProcessorMap("scheduleCronJob", &auroraSchedulerManagerProcessorScheduleCronJob{handler: handler})
-	self160.AddToProcessorMap("descheduleCronJob", &auroraSchedulerManagerProcessorDescheduleCronJob{handler: handler})
-	self160.AddToProcessorMap("startCronJob", &auroraSchedulerManagerProcessorStartCronJob{handler: handler})
-	self160.AddToProcessorMap("restartShards", &auroraSchedulerManagerProcessorRestartShards{handler: handler})
-	self160.AddToProcessorMap("killTasks", &auroraSchedulerManagerProcessorKillTasks{handler: handler})
-	self160.AddToProcessorMap("addInstances", &auroraSchedulerManagerProcessorAddInstances{handler: handler})
-	self160.AddToProcessorMap("replaceCronTemplate", &auroraSchedulerManagerProcessorReplaceCronTemplate{handler: handler})
-	self160.AddToProcessorMap("startJobUpdate", &auroraSchedulerManagerProcessorStartJobUpdate{handler: handler})
-	self160.AddToProcessorMap("pauseJobUpdate", &auroraSchedulerManagerProcessorPauseJobUpdate{handler: handler})
-	self160.AddToProcessorMap("resumeJobUpdate", &auroraSchedulerManagerProcessorResumeJobUpdate{handler: handler})
-	self160.AddToProcessorMap("abortJobUpdate", &auroraSchedulerManagerProcessorAbortJobUpdate{handler: handler})
-	self160.AddToProcessorMap("rollbackJobUpdate", &auroraSchedulerManagerProcessorRollbackJobUpdate{handler: handler})
-	self160.AddToProcessorMap("pulseJobUpdate", &auroraSchedulerManagerProcessorPulseJobUpdate{handler: handler})
-	return self160
+	self161 := &AuroraSchedulerManagerProcessor{NewReadOnlySchedulerProcessor(handler)}
+	self161.AddToProcessorMap("createJob", &auroraSchedulerManagerProcessorCreateJob{handler: handler})
+	self161.AddToProcessorMap("scheduleCronJob", &auroraSchedulerManagerProcessorScheduleCronJob{handler: handler})
+	self161.AddToProcessorMap("descheduleCronJob", &auroraSchedulerManagerProcessorDescheduleCronJob{handler: handler})
+	self161.AddToProcessorMap("startCronJob", &auroraSchedulerManagerProcessorStartCronJob{handler: handler})
+	self161.AddToProcessorMap("restartShards", &auroraSchedulerManagerProcessorRestartShards{handler: handler})
+	self161.AddToProcessorMap("killTasks", &auroraSchedulerManagerProcessorKillTasks{handler: handler})
+	self161.AddToProcessorMap("addInstances", &auroraSchedulerManagerProcessorAddInstances{handler: handler})
+	self161.AddToProcessorMap("replaceCronTemplate", &auroraSchedulerManagerProcessorReplaceCronTemplate{handler: handler})
+	self161.AddToProcessorMap("startJobUpdate", &auroraSchedulerManagerProcessorStartJobUpdate{handler: handler})
+	self161.AddToProcessorMap("pauseJobUpdate", &auroraSchedulerManagerProcessorPauseJobUpdate{handler: handler})
+	self161.AddToProcessorMap("resumeJobUpdate", &auroraSchedulerManagerProcessorResumeJobUpdate{handler: handler})
+	self161.AddToProcessorMap("abortJobUpdate", &auroraSchedulerManagerProcessorAbortJobUpdate{handler: handler})
+	self161.AddToProcessorMap("rollbackJobUpdate", &auroraSchedulerManagerProcessorRollbackJobUpdate{handler: handler})
+	self161.AddToProcessorMap("pulseJobUpdate", &auroraSchedulerManagerProcessorPulseJobUpdate{handler: handler})
+	return self161
 }
 
 type auroraSchedulerManagerProcessorCreateJob struct {
@@ -1530,7 +1533,7 @@ func (p *auroraSchedulerManagerProcessorKillTasks) Process(seqId int32, iprot, o
 	result := AuroraSchedulerManagerKillTasksResult{}
 	var retval *Response
 	var err2 error
-	if retval, err2 = p.handler.KillTasks(args.Job, args.Instances); err2 != nil {
+	if retval, err2 = p.handler.KillTasks(args.Job, args.Instances, args.Message); err2 != nil {
 		x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing killTasks: "+err2.Error())
 		oprot.WriteMessageBegin("killTasks", thrift.EXCEPTION, seqId)
 		x.Write(oprot)
@@ -2829,13 +2832,13 @@ func (p *AuroraSchedulerManagerRestartShardsArgs) readField3(iprot thrift.TProto
 	tSet := make(map[int32]bool, size)
 	p.ShardIds = tSet
 	for i := 0; i < size; i++ {
-		var _elem161 int32
+		var _elem162 int32
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem161 = v
+			_elem162 = v
 		}
-		p.ShardIds[_elem161] = true
+		p.ShardIds[_elem162] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -3007,10 +3010,12 @@ func (p *AuroraSchedulerManagerRestartShardsResult) String() string {
 // Attributes:
 //  - Job
 //  - Instances
+//  - Message
 type AuroraSchedulerManagerKillTasksArgs struct {
 	// unused fields # 1 to 3
 	Job       *JobKey        `thrift:"job,4" json:"job"`
 	Instances map[int32]bool `thrift:"instances,5" json:"instances"`
+	Message   string         `thrift:"message,6" json:"message"`
 }
 
 func NewAuroraSchedulerManagerKillTasksArgs() *AuroraSchedulerManagerKillTasksArgs {
@@ -3028,6 +3033,10 @@ func (p *AuroraSchedulerManagerKillTasksArgs) GetJob() *JobKey {
 
 func (p *AuroraSchedulerManagerKillTasksArgs) GetInstances() map[int32]bool {
 	return p.Instances
+}
+
+func (p *AuroraSchedulerManagerKillTasksArgs) GetMessage() string {
+	return p.Message
 }
 func (p *AuroraSchedulerManagerKillTasksArgs) IsSetJob() bool {
 	return p.Job != nil
@@ -3053,6 +3062,10 @@ func (p *AuroraSchedulerManagerKillTasksArgs) Read(iprot thrift.TProtocol) error
 			}
 		case 5:
 			if err := p.readField5(iprot); err != nil {
+				return err
+			}
+		case 6:
+			if err := p.readField6(iprot); err != nil {
 				return err
 			}
 		default:
@@ -3086,16 +3099,25 @@ func (p *AuroraSchedulerManagerKillTasksArgs) readField5(iprot thrift.TProtocol)
 	tSet := make(map[int32]bool, size)
 	p.Instances = tSet
 	for i := 0; i < size; i++ {
-		var _elem162 int32
+		var _elem163 int32
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem162 = v
+			_elem163 = v
 		}
-		p.Instances[_elem162] = true
+		p.Instances[_elem163] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
+	}
+	return nil
+}
+
+func (p *AuroraSchedulerManagerKillTasksArgs) readField6(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 6: ", err)
+	} else {
+		p.Message = v
 	}
 	return nil
 }
@@ -3108,6 +3130,9 @@ func (p *AuroraSchedulerManagerKillTasksArgs) Write(oprot thrift.TProtocol) erro
 		return err
 	}
 	if err := p.writeField5(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField6(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -3149,6 +3174,19 @@ func (p *AuroraSchedulerManagerKillTasksArgs) writeField5(oprot thrift.TProtocol
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 5:instances: ", p), err)
+	}
+	return err
+}
+
+func (p *AuroraSchedulerManagerKillTasksArgs) writeField6(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("message", thrift.STRING, 6); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:message: ", p), err)
+	}
+	if err := oprot.WriteString(string(p.Message)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.message (6) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 6:message: ", p), err)
 	}
 	return err
 }

--- a/gen-go/apache/aurora/read_only_scheduler-remote/read_only_scheduler-remote.go
+++ b/gen-go/apache/aurora/read_only_scheduler-remote/read_only_scheduler-remote.go
@@ -150,19 +150,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksStatus requires 1 args")
 			flag.Usage()
 		}
-		arg82 := flag.Arg(1)
-		mbTrans83 := thrift.NewTMemoryBufferLen(len(arg82))
-		defer mbTrans83.Close()
-		_, err84 := mbTrans83.WriteString(arg82)
-		if err84 != nil {
+		arg83 := flag.Arg(1)
+		mbTrans84 := thrift.NewTMemoryBufferLen(len(arg83))
+		defer mbTrans84.Close()
+		_, err85 := mbTrans84.WriteString(arg83)
+		if err85 != nil {
 			Usage()
 			return
 		}
-		factory85 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt86 := factory85.GetProtocol(mbTrans83)
+		factory86 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt87 := factory86.GetProtocol(mbTrans84)
 		argvalue0 := aurora.NewTaskQuery()
-		err87 := argvalue0.Read(jsProt86)
-		if err87 != nil {
+		err88 := argvalue0.Read(jsProt87)
+		if err88 != nil {
 			Usage()
 			return
 		}
@@ -175,19 +175,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetTasksWithoutConfigs requires 1 args")
 			flag.Usage()
 		}
-		arg88 := flag.Arg(1)
-		mbTrans89 := thrift.NewTMemoryBufferLen(len(arg88))
-		defer mbTrans89.Close()
-		_, err90 := mbTrans89.WriteString(arg88)
-		if err90 != nil {
+		arg89 := flag.Arg(1)
+		mbTrans90 := thrift.NewTMemoryBufferLen(len(arg89))
+		defer mbTrans90.Close()
+		_, err91 := mbTrans90.WriteString(arg89)
+		if err91 != nil {
 			Usage()
 			return
 		}
-		factory91 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt92 := factory91.GetProtocol(mbTrans89)
+		factory92 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt93 := factory92.GetProtocol(mbTrans90)
 		argvalue0 := aurora.NewTaskQuery()
-		err93 := argvalue0.Read(jsProt92)
-		if err93 != nil {
+		err94 := argvalue0.Read(jsProt93)
+		if err94 != nil {
 			Usage()
 			return
 		}
@@ -200,19 +200,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetPendingReason requires 1 args")
 			flag.Usage()
 		}
-		arg94 := flag.Arg(1)
-		mbTrans95 := thrift.NewTMemoryBufferLen(len(arg94))
-		defer mbTrans95.Close()
-		_, err96 := mbTrans95.WriteString(arg94)
-		if err96 != nil {
+		arg95 := flag.Arg(1)
+		mbTrans96 := thrift.NewTMemoryBufferLen(len(arg95))
+		defer mbTrans96.Close()
+		_, err97 := mbTrans96.WriteString(arg95)
+		if err97 != nil {
 			Usage()
 			return
 		}
-		factory97 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt98 := factory97.GetProtocol(mbTrans95)
+		factory98 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt99 := factory98.GetProtocol(mbTrans96)
 		argvalue0 := aurora.NewTaskQuery()
-		err99 := argvalue0.Read(jsProt98)
-		if err99 != nil {
+		err100 := argvalue0.Read(jsProt99)
+		if err100 != nil {
 			Usage()
 			return
 		}
@@ -225,19 +225,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetConfigSummary requires 1 args")
 			flag.Usage()
 		}
-		arg100 := flag.Arg(1)
-		mbTrans101 := thrift.NewTMemoryBufferLen(len(arg100))
-		defer mbTrans101.Close()
-		_, err102 := mbTrans101.WriteString(arg100)
-		if err102 != nil {
+		arg101 := flag.Arg(1)
+		mbTrans102 := thrift.NewTMemoryBufferLen(len(arg101))
+		defer mbTrans102.Close()
+		_, err103 := mbTrans102.WriteString(arg101)
+		if err103 != nil {
 			Usage()
 			return
 		}
-		factory103 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt104 := factory103.GetProtocol(mbTrans101)
+		factory104 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt105 := factory104.GetProtocol(mbTrans102)
 		argvalue0 := aurora.NewJobKey()
-		err105 := argvalue0.Read(jsProt104)
-		if err105 != nil {
+		err106 := argvalue0.Read(jsProt105)
+		if err106 != nil {
 			Usage()
 			return
 		}
@@ -270,19 +270,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PopulateJobConfig requires 1 args")
 			flag.Usage()
 		}
-		arg108 := flag.Arg(1)
-		mbTrans109 := thrift.NewTMemoryBufferLen(len(arg108))
-		defer mbTrans109.Close()
-		_, err110 := mbTrans109.WriteString(arg108)
-		if err110 != nil {
+		arg109 := flag.Arg(1)
+		mbTrans110 := thrift.NewTMemoryBufferLen(len(arg109))
+		defer mbTrans110.Close()
+		_, err111 := mbTrans110.WriteString(arg109)
+		if err111 != nil {
 			Usage()
 			return
 		}
-		factory111 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt112 := factory111.GetProtocol(mbTrans109)
+		factory112 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt113 := factory112.GetProtocol(mbTrans110)
 		argvalue0 := aurora.NewJobConfiguration()
-		err113 := argvalue0.Read(jsProt112)
-		if err113 != nil {
+		err114 := argvalue0.Read(jsProt113)
+		if err114 != nil {
 			Usage()
 			return
 		}
@@ -295,19 +295,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateSummaries requires 1 args")
 			flag.Usage()
 		}
-		arg114 := flag.Arg(1)
-		mbTrans115 := thrift.NewTMemoryBufferLen(len(arg114))
-		defer mbTrans115.Close()
-		_, err116 := mbTrans115.WriteString(arg114)
-		if err116 != nil {
+		arg115 := flag.Arg(1)
+		mbTrans116 := thrift.NewTMemoryBufferLen(len(arg115))
+		defer mbTrans116.Close()
+		_, err117 := mbTrans116.WriteString(arg115)
+		if err117 != nil {
 			Usage()
 			return
 		}
-		factory117 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt118 := factory117.GetProtocol(mbTrans115)
+		factory118 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt119 := factory118.GetProtocol(mbTrans116)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err119 := argvalue0.Read(jsProt118)
-		if err119 != nil {
+		err120 := argvalue0.Read(jsProt119)
+		if err120 != nil {
 			Usage()
 			return
 		}
@@ -320,19 +320,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDetails requires 1 args")
 			flag.Usage()
 		}
-		arg120 := flag.Arg(1)
-		mbTrans121 := thrift.NewTMemoryBufferLen(len(arg120))
-		defer mbTrans121.Close()
-		_, err122 := mbTrans121.WriteString(arg120)
-		if err122 != nil {
+		arg121 := flag.Arg(1)
+		mbTrans122 := thrift.NewTMemoryBufferLen(len(arg121))
+		defer mbTrans122.Close()
+		_, err123 := mbTrans122.WriteString(arg121)
+		if err123 != nil {
 			Usage()
 			return
 		}
-		factory123 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt124 := factory123.GetProtocol(mbTrans121)
+		factory124 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt125 := factory124.GetProtocol(mbTrans122)
 		argvalue0 := aurora.NewJobUpdateQuery()
-		err125 := argvalue0.Read(jsProt124)
-		if err125 != nil {
+		err126 := argvalue0.Read(jsProt125)
+		if err126 != nil {
 			Usage()
 			return
 		}
@@ -345,19 +345,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetJobUpdateDiff requires 1 args")
 			flag.Usage()
 		}
-		arg126 := flag.Arg(1)
-		mbTrans127 := thrift.NewTMemoryBufferLen(len(arg126))
-		defer mbTrans127.Close()
-		_, err128 := mbTrans127.WriteString(arg126)
-		if err128 != nil {
+		arg127 := flag.Arg(1)
+		mbTrans128 := thrift.NewTMemoryBufferLen(len(arg127))
+		defer mbTrans128.Close()
+		_, err129 := mbTrans128.WriteString(arg127)
+		if err129 != nil {
 			Usage()
 			return
 		}
-		factory129 := thrift.NewTSimpleJSONProtocolFactory()
-		jsProt130 := factory129.GetProtocol(mbTrans127)
+		factory130 := thrift.NewTSimpleJSONProtocolFactory()
+		jsProt131 := factory130.GetProtocol(mbTrans128)
 		argvalue0 := aurora.NewJobUpdateRequest()
-		err131 := argvalue0.Read(jsProt130)
-		if err131 != nil {
+		err132 := argvalue0.Read(jsProt131)
+		if err132 != nil {
 			Usage()
 			return
 		}

--- a/gen-go/apache/aurora/readonlyscheduler.go
+++ b/gen-go/apache/aurora/readonlyscheduler.go
@@ -152,16 +152,16 @@ func (p *ReadOnlySchedulerClient) recvGetRoleSummary() (value *Response, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error53 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error54 error
-		error54, err = error53.Read(iprot)
+		error54 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error55 error
+		error55, err = error54.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error54
+		err = error55
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -231,16 +231,16 @@ func (p *ReadOnlySchedulerClient) recvGetJobSummary() (value *Response, err erro
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error55 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error56 error
-		error56, err = error55.Read(iprot)
+		error56 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error57 error
+		error57, err = error56.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error56
+		err = error57
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -310,16 +310,16 @@ func (p *ReadOnlySchedulerClient) recvGetTasksStatus() (value *Response, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error57 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error58 error
-		error58, err = error57.Read(iprot)
+		error58 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error59 error
+		error59, err = error58.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error58
+		err = error59
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -390,16 +390,16 @@ func (p *ReadOnlySchedulerClient) recvGetTasksWithoutConfigs() (value *Response,
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error59 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error60 error
-		error60, err = error59.Read(iprot)
+		error60 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error61 error
+		error61, err = error60.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error60
+		err = error61
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -469,16 +469,16 @@ func (p *ReadOnlySchedulerClient) recvGetPendingReason() (value *Response, err e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error61 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error62 error
-		error62, err = error61.Read(iprot)
+		error62 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error63 error
+		error63, err = error62.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error62
+		err = error63
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -548,16 +548,16 @@ func (p *ReadOnlySchedulerClient) recvGetConfigSummary() (value *Response, err e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error63 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error64 error
-		error64, err = error63.Read(iprot)
+		error64 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error65 error
+		error65, err = error64.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error64
+		err = error65
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -628,16 +628,16 @@ func (p *ReadOnlySchedulerClient) recvGetJobs() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error65 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error66 error
-		error66, err = error65.Read(iprot)
+		error66 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error67 error
+		error67, err = error66.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error66
+		err = error67
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -707,16 +707,16 @@ func (p *ReadOnlySchedulerClient) recvGetQuota() (value *Response, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error67 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error68 error
-		error68, err = error67.Read(iprot)
+		error68 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error69 error
+		error69, err = error68.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error68
+		err = error69
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -787,16 +787,16 @@ func (p *ReadOnlySchedulerClient) recvPopulateJobConfig() (value *Response, err 
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error69 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error70 error
-		error70, err = error69.Read(iprot)
+		error70 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error71 error
+		error71, err = error70.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error70
+		err = error71
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -866,16 +866,16 @@ func (p *ReadOnlySchedulerClient) recvGetJobUpdateSummaries() (value *Response, 
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error71 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error72 error
-		error72, err = error71.Read(iprot)
+		error72 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error73 error
+		error73, err = error72.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error72
+		err = error73
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -945,16 +945,16 @@ func (p *ReadOnlySchedulerClient) recvGetJobUpdateDetails() (value *Response, er
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error73 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error74 error
-		error74, err = error73.Read(iprot)
+		error74 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error75 error
+		error75, err = error74.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error74
+		err = error75
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1024,16 +1024,16 @@ func (p *ReadOnlySchedulerClient) recvGetJobUpdateDiff() (value *Response, err e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error75 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error76 error
-		error76, err = error75.Read(iprot)
+		error76 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error77 error
+		error77, err = error76.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error76
+		err = error77
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1098,16 +1098,16 @@ func (p *ReadOnlySchedulerClient) recvGetTierConfigs() (value *Response, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error77 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error78 error
-		error78, err = error77.Read(iprot)
+		error78 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error79 error
+		error79, err = error78.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error78
+		err = error79
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -1145,21 +1145,21 @@ func (p *ReadOnlySchedulerProcessor) ProcessorMap() map[string]thrift.TProcessor
 
 func NewReadOnlySchedulerProcessor(handler ReadOnlyScheduler) *ReadOnlySchedulerProcessor {
 
-	self79 := &ReadOnlySchedulerProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self79.processorMap["getRoleSummary"] = &readOnlySchedulerProcessorGetRoleSummary{handler: handler}
-	self79.processorMap["getJobSummary"] = &readOnlySchedulerProcessorGetJobSummary{handler: handler}
-	self79.processorMap["getTasksStatus"] = &readOnlySchedulerProcessorGetTasksStatus{handler: handler}
-	self79.processorMap["getTasksWithoutConfigs"] = &readOnlySchedulerProcessorGetTasksWithoutConfigs{handler: handler}
-	self79.processorMap["getPendingReason"] = &readOnlySchedulerProcessorGetPendingReason{handler: handler}
-	self79.processorMap["getConfigSummary"] = &readOnlySchedulerProcessorGetConfigSummary{handler: handler}
-	self79.processorMap["getJobs"] = &readOnlySchedulerProcessorGetJobs{handler: handler}
-	self79.processorMap["getQuota"] = &readOnlySchedulerProcessorGetQuota{handler: handler}
-	self79.processorMap["populateJobConfig"] = &readOnlySchedulerProcessorPopulateJobConfig{handler: handler}
-	self79.processorMap["getJobUpdateSummaries"] = &readOnlySchedulerProcessorGetJobUpdateSummaries{handler: handler}
-	self79.processorMap["getJobUpdateDetails"] = &readOnlySchedulerProcessorGetJobUpdateDetails{handler: handler}
-	self79.processorMap["getJobUpdateDiff"] = &readOnlySchedulerProcessorGetJobUpdateDiff{handler: handler}
-	self79.processorMap["getTierConfigs"] = &readOnlySchedulerProcessorGetTierConfigs{handler: handler}
-	return self79
+	self80 := &ReadOnlySchedulerProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self80.processorMap["getRoleSummary"] = &readOnlySchedulerProcessorGetRoleSummary{handler: handler}
+	self80.processorMap["getJobSummary"] = &readOnlySchedulerProcessorGetJobSummary{handler: handler}
+	self80.processorMap["getTasksStatus"] = &readOnlySchedulerProcessorGetTasksStatus{handler: handler}
+	self80.processorMap["getTasksWithoutConfigs"] = &readOnlySchedulerProcessorGetTasksWithoutConfigs{handler: handler}
+	self80.processorMap["getPendingReason"] = &readOnlySchedulerProcessorGetPendingReason{handler: handler}
+	self80.processorMap["getConfigSummary"] = &readOnlySchedulerProcessorGetConfigSummary{handler: handler}
+	self80.processorMap["getJobs"] = &readOnlySchedulerProcessorGetJobs{handler: handler}
+	self80.processorMap["getQuota"] = &readOnlySchedulerProcessorGetQuota{handler: handler}
+	self80.processorMap["populateJobConfig"] = &readOnlySchedulerProcessorPopulateJobConfig{handler: handler}
+	self80.processorMap["getJobUpdateSummaries"] = &readOnlySchedulerProcessorGetJobUpdateSummaries{handler: handler}
+	self80.processorMap["getJobUpdateDetails"] = &readOnlySchedulerProcessorGetJobUpdateDetails{handler: handler}
+	self80.processorMap["getJobUpdateDiff"] = &readOnlySchedulerProcessorGetJobUpdateDiff{handler: handler}
+	self80.processorMap["getTierConfigs"] = &readOnlySchedulerProcessorGetTierConfigs{handler: handler}
+	return self80
 }
 
 func (p *ReadOnlySchedulerProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -1172,12 +1172,12 @@ func (p *ReadOnlySchedulerProcessor) Process(iprot, oprot thrift.TProtocol) (suc
 	}
 	iprot.Skip(thrift.STRUCT)
 	iprot.ReadMessageEnd()
-	x80 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x81 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x80.Write(oprot)
+	x81.Write(oprot)
 	oprot.WriteMessageEnd()
 	oprot.Flush()
-	return false, x80
+	return false, x81
 
 }
 

--- a/gen-go/apache/aurora/ttypes.go
+++ b/gen-go/apache/aurora/ttypes.go
@@ -3400,8 +3400,10 @@ func (p *Image) String() string {
 //
 // Attributes:
 //  - Image: the optional filesystem image to use when launching this task.
+//  - Volumes: the optional list of volumes to mount into the task.
 type MesosContainer struct {
-	Image *Image `thrift:"image,1" json:"image,omitempty"`
+	Image   *Image    `thrift:"image,1" json:"image,omitempty"`
+	Volumes []*Volume `thrift:"volumes,2" json:"volumes,omitempty"`
 }
 
 func NewMesosContainer() *MesosContainer {
@@ -3416,8 +3418,18 @@ func (p *MesosContainer) GetImage() *Image {
 	}
 	return p.Image
 }
+
+var MesosContainer_Volumes_DEFAULT []*Volume
+
+func (p *MesosContainer) GetVolumes() []*Volume {
+	return p.Volumes
+}
 func (p *MesosContainer) IsSetImage() bool {
 	return p.Image != nil
+}
+
+func (p *MesosContainer) IsSetVolumes() bool {
+	return p.Volumes != nil
 }
 
 func (p *MesosContainer) Read(iprot thrift.TProtocol) error {
@@ -3436,6 +3448,10 @@ func (p *MesosContainer) Read(iprot thrift.TProtocol) error {
 		switch fieldId {
 		case 1:
 			if err := p.readField1(iprot); err != nil {
+				return err
+			}
+		case 2:
+			if err := p.readField2(iprot); err != nil {
 				return err
 			}
 		default:
@@ -3461,11 +3477,34 @@ func (p *MesosContainer) readField1(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *MesosContainer) readField2(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	tSlice := make([]*Volume, 0, size)
+	p.Volumes = tSlice
+	for i := 0; i < size; i++ {
+		_elem3 := &Volume{}
+		if err := _elem3.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem3), err)
+		}
+		p.Volumes = append(p.Volumes, _elem3)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
 func (p *MesosContainer) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("MesosContainer"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 	}
 	if err := p.writeField1(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField2(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -3487,6 +3526,29 @@ func (p *MesosContainer) writeField1(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:image: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *MesosContainer) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetVolumes() {
+		if err := oprot.WriteFieldBegin("volumes", thrift.LIST, 2); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:volumes: ", p), err)
+		}
+		if err := oprot.WriteListBegin(thrift.STRUCT, len(p.Volumes)); err != nil {
+			return thrift.PrependError("error writing list begin: ", err)
+		}
+		for _, v := range p.Volumes {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return thrift.PrependError("error writing list end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 2:volumes: ", p), err)
 		}
 	}
 	return err
@@ -3708,11 +3770,11 @@ func (p *DockerContainer) readField2(iprot thrift.TProtocol) error {
 	tSlice := make([]*DockerParameter, 0, size)
 	p.Parameters = tSlice
 	for i := 0; i < size; i++ {
-		_elem3 := &DockerParameter{}
-		if err := _elem3.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem3), err)
+		_elem4 := &DockerParameter{}
+		if err := _elem4.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem4), err)
 		}
-		p.Parameters = append(p.Parameters, _elem3)
+		p.Parameters = append(p.Parameters, _elem4)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -4673,11 +4735,11 @@ func (p *TaskConfig) readField32(iprot thrift.TProtocol) error {
 	tSet := make(map[*Resource]bool, size)
 	p.Resources = tSet
 	for i := 0; i < size; i++ {
-		_elem4 := &Resource{}
-		if err := _elem4.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem4), err)
+		_elem5 := &Resource{}
+		if err := _elem5.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem5), err)
 		}
-		p.Resources[_elem4] = true
+		p.Resources[_elem5] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -4693,11 +4755,11 @@ func (p *TaskConfig) readField20(iprot thrift.TProtocol) error {
 	tSet := make(map[*Constraint]bool, size)
 	p.Constraints = tSet
 	for i := 0; i < size; i++ {
-		_elem5 := &Constraint{}
-		if err := _elem5.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem5), err)
+		_elem6 := &Constraint{}
+		if err := _elem6.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem6), err)
 		}
-		p.Constraints[_elem5] = true
+		p.Constraints[_elem6] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -4713,13 +4775,13 @@ func (p *TaskConfig) readField21(iprot thrift.TProtocol) error {
 	tSet := make(map[string]bool, size)
 	p.RequestedPorts = tSet
 	for i := 0; i < size; i++ {
-		var _elem6 string
+		var _elem7 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem6 = v
+			_elem7 = v
 		}
-		p.RequestedPorts[_elem6] = true
+		p.RequestedPorts[_elem7] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -4735,11 +4797,11 @@ func (p *TaskConfig) readField33(iprot thrift.TProtocol) error {
 	tSet := make(map[*MesosFetcherURI]bool, size)
 	p.MesosFetcherUris = tSet
 	for i := 0; i < size; i++ {
-		_elem7 := &MesosFetcherURI{}
-		if err := _elem7.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem7), err)
+		_elem8 := &MesosFetcherURI{}
+		if err := _elem8.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem8), err)
 		}
-		p.MesosFetcherUris[_elem7] = true
+		p.MesosFetcherUris[_elem8] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -4755,19 +4817,19 @@ func (p *TaskConfig) readField22(iprot thrift.TProtocol) error {
 	tMap := make(map[string]string, size)
 	p.TaskLinks = tMap
 	for i := 0; i < size; i++ {
-		var _key8 string
+		var _key9 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_key8 = v
+			_key9 = v
 		}
-		var _val9 string
+		var _val10 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_val9 = v
+			_val10 = v
 		}
-		p.TaskLinks[_key8] = _val9
+		p.TaskLinks[_key9] = _val10
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -4800,11 +4862,11 @@ func (p *TaskConfig) readField27(iprot thrift.TProtocol) error {
 	tSet := make(map[*Metadata]bool, size)
 	p.Metadata = tSet
 	for i := 0; i < size; i++ {
-		_elem10 := &Metadata{}
-		if err := _elem10.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem10), err)
+		_elem11 := &Metadata{}
+		if err := _elem11.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem11), err)
 		}
-		p.Metadata[_elem10] = true
+		p.Metadata[_elem11] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -5320,11 +5382,11 @@ func (p *ResourceAggregate) readField4(iprot thrift.TProtocol) error {
 	tSet := make(map[*Resource]bool, size)
 	p.Resources = tSet
 	for i := 0; i < size; i++ {
-		_elem11 := &Resource{}
-		if err := _elem11.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem11), err)
+		_elem12 := &Resource{}
+		if err := _elem12.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem12), err)
 		}
-		p.Resources[_elem11] = true
+		p.Resources[_elem12] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -6325,11 +6387,11 @@ func (p *ConfigGroup) readField3(iprot thrift.TProtocol) error {
 	tSet := make(map[*Range]bool, size)
 	p.Instances = tSet
 	for i := 0; i < size; i++ {
-		_elem12 := &Range{}
-		if err := _elem12.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem12), err)
+		_elem13 := &Range{}
+		if err := _elem13.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem13), err)
 		}
-		p.Instances[_elem12] = true
+		p.Instances[_elem13] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -6478,11 +6540,11 @@ func (p *ConfigSummary) readField2(iprot thrift.TProtocol) error {
 	tSet := make(map[*ConfigGroup]bool, size)
 	p.Groups = tSet
 	for i := 0; i < size; i++ {
-		_elem13 := &ConfigGroup{}
-		if err := _elem13.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem13), err)
+		_elem14 := &ConfigGroup{}
+		if err := _elem14.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem14), err)
 		}
-		p.Groups[_elem13] = true
+		p.Groups[_elem14] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -7303,19 +7365,19 @@ func (p *AssignedTask) readField5(iprot thrift.TProtocol) error {
 	tMap := make(map[string]int32, size)
 	p.AssignedPorts = tMap
 	for i := 0; i < size; i++ {
-		var _key14 string
+		var _key15 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_key14 = v
+			_key15 = v
 		}
-		var _val15 int32
+		var _val16 int32
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_val15 = v
+			_val16 = v
 		}
-		p.AssignedPorts[_key14] = _val15
+		p.AssignedPorts[_key15] = _val16
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -7593,11 +7655,11 @@ func (p *ScheduledTask) readField4(iprot thrift.TProtocol) error {
 	tSlice := make([]*TaskEvent, 0, size)
 	p.TaskEvents = tSlice
 	for i := 0; i < size; i++ {
-		_elem16 := &TaskEvent{}
-		if err := _elem16.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem16), err)
+		_elem17 := &TaskEvent{}
+		if err := _elem17.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem17), err)
 		}
-		p.TaskEvents = append(p.TaskEvents, _elem16)
+		p.TaskEvents = append(p.TaskEvents, _elem17)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -7776,11 +7838,11 @@ func (p *ScheduleStatusResult_) readField1(iprot thrift.TProtocol) error {
 	tSlice := make([]*ScheduledTask, 0, size)
 	p.Tasks = tSlice
 	for i := 0; i < size; i++ {
-		_elem17 := &ScheduledTask{}
-		if err := _elem17.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem17), err)
+		_elem18 := &ScheduledTask{}
+		if err := _elem18.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem18), err)
 		}
-		p.Tasks = append(p.Tasks, _elem17)
+		p.Tasks = append(p.Tasks, _elem18)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -7886,11 +7948,11 @@ func (p *GetJobsResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*JobConfiguration]bool, size)
 	p.Configs = tSet
 	for i := 0; i < size; i++ {
-		_elem18 := &JobConfiguration{}
-		if err := _elem18.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem18), err)
+		_elem19 := &JobConfiguration{}
+		if err := _elem19.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem19), err)
 		}
-		p.Configs[_elem18] = true
+		p.Configs[_elem19] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8120,13 +8182,13 @@ func (p *TaskQuery) readField4(iprot thrift.TProtocol) error {
 	tSet := make(map[string]bool, size)
 	p.TaskIds = tSet
 	for i := 0; i < size; i++ {
-		var _elem19 string
+		var _elem20 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem19 = v
+			_elem20 = v
 		}
-		p.TaskIds[_elem19] = true
+		p.TaskIds[_elem20] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8142,14 +8204,14 @@ func (p *TaskQuery) readField5(iprot thrift.TProtocol) error {
 	tSet := make(map[ScheduleStatus]bool, size)
 	p.Statuses = tSet
 	for i := 0; i < size; i++ {
-		var _elem20 ScheduleStatus
+		var _elem21 ScheduleStatus
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ScheduleStatus(v)
-			_elem20 = temp
+			_elem21 = temp
 		}
-		p.Statuses[_elem20] = true
+		p.Statuses[_elem21] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8165,13 +8227,13 @@ func (p *TaskQuery) readField7(iprot thrift.TProtocol) error {
 	tSet := make(map[int32]bool, size)
 	p.InstanceIds = tSet
 	for i := 0; i < size; i++ {
-		var _elem21 int32
+		var _elem22 int32
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem21 = v
+			_elem22 = v
 		}
-		p.InstanceIds[_elem21] = true
+		p.InstanceIds[_elem22] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8187,13 +8249,13 @@ func (p *TaskQuery) readField10(iprot thrift.TProtocol) error {
 	tSet := make(map[string]bool, size)
 	p.SlaveHosts = tSet
 	for i := 0; i < size; i++ {
-		var _elem22 string
+		var _elem23 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem22 = v
+			_elem23 = v
 		}
-		p.SlaveHosts[_elem22] = true
+		p.SlaveHosts[_elem23] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8209,11 +8271,11 @@ func (p *TaskQuery) readField11(iprot thrift.TProtocol) error {
 	tSet := make(map[*JobKey]bool, size)
 	p.JobKeys = tSet
 	for i := 0; i < size; i++ {
-		_elem23 := &JobKey{}
-		if err := _elem23.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem23), err)
+		_elem24 := &JobKey{}
+		if err := _elem24.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem24), err)
 		}
-		p.JobKeys[_elem23] = true
+		p.JobKeys[_elem24] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -8801,13 +8863,13 @@ func (p *Hosts) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[string]bool, size)
 	p.HostNames = tSet
 	for i := 0; i < size; i++ {
-		var _elem24 string
+		var _elem25 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem24 = v
+			_elem25 = v
 		}
-		p.HostNames[_elem24] = true
+		p.HostNames[_elem25] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -9306,11 +9368,11 @@ func (p *JobUpdateSettings) readField7(iprot thrift.TProtocol) error {
 	tSet := make(map[*Range]bool, size)
 	p.UpdateOnlyTheseInstances = tSet
 	for i := 0; i < size; i++ {
-		_elem25 := &Range{}
-		if err := _elem25.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem25), err)
+		_elem26 := &Range{}
+		if err := _elem26.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem26), err)
 		}
-		p.UpdateOnlyTheseInstances[_elem25] = true
+		p.UpdateOnlyTheseInstances[_elem26] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -9963,11 +10025,11 @@ func (p *InstanceTaskConfig) readField2(iprot thrift.TProtocol) error {
 	tSet := make(map[*Range]bool, size)
 	p.Instances = tSet
 	for i := 0; i < size; i++ {
-		_elem26 := &Range{}
-		if err := _elem26.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem26), err)
+		_elem27 := &Range{}
+		if err := _elem27.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem27), err)
 		}
-		p.Instances[_elem26] = true
+		p.Instances[_elem27] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -10335,11 +10397,11 @@ func (p *JobUpdateSummary) readField6(iprot thrift.TProtocol) error {
 	tSet := make(map[*Metadata]bool, size)
 	p.Metadata = tSet
 	for i := 0; i < size; i++ {
-		_elem27 := &Metadata{}
-		if err := _elem27.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem27), err)
+		_elem28 := &Metadata{}
+		if err := _elem28.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem28), err)
 		}
-		p.Metadata[_elem27] = true
+		p.Metadata[_elem28] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -10535,11 +10597,11 @@ func (p *JobUpdateInstructions) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*InstanceTaskConfig]bool, size)
 	p.InitialState = tSet
 	for i := 0; i < size; i++ {
-		_elem28 := &InstanceTaskConfig{}
-		if err := _elem28.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem28), err)
+		_elem29 := &InstanceTaskConfig{}
+		if err := _elem29.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem29), err)
 		}
-		p.InitialState[_elem28] = true
+		p.InitialState[_elem29] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -10874,11 +10936,11 @@ func (p *JobUpdateDetails) readField2(iprot thrift.TProtocol) error {
 	tSlice := make([]*JobUpdateEvent, 0, size)
 	p.UpdateEvents = tSlice
 	for i := 0; i < size; i++ {
-		_elem29 := &JobUpdateEvent{}
-		if err := _elem29.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem29), err)
+		_elem30 := &JobUpdateEvent{}
+		if err := _elem30.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem30), err)
 		}
-		p.UpdateEvents = append(p.UpdateEvents, _elem29)
+		p.UpdateEvents = append(p.UpdateEvents, _elem30)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -10894,11 +10956,11 @@ func (p *JobUpdateDetails) readField3(iprot thrift.TProtocol) error {
 	tSlice := make([]*JobInstanceUpdateEvent, 0, size)
 	p.InstanceEvents = tSlice
 	for i := 0; i < size; i++ {
-		_elem30 := &JobInstanceUpdateEvent{}
-		if err := _elem30.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem30), err)
+		_elem31 := &JobInstanceUpdateEvent{}
+		if err := _elem31.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem31), err)
 		}
-		p.InstanceEvents = append(p.InstanceEvents, _elem30)
+		p.InstanceEvents = append(p.InstanceEvents, _elem31)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -11125,11 +11187,11 @@ func (p *JobUpdateRequest) readField4(iprot thrift.TProtocol) error {
 	tSet := make(map[*Metadata]bool, size)
 	p.Metadata = tSet
 	for i := 0; i < size; i++ {
-		_elem31 := &Metadata{}
-		if err := _elem31.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem31), err)
+		_elem32 := &Metadata{}
+		if err := _elem32.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem32), err)
 		}
-		p.Metadata[_elem31] = true
+		p.Metadata[_elem32] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -11425,14 +11487,14 @@ func (p *JobUpdateQuery) readField5(iprot thrift.TProtocol) error {
 	tSet := make(map[JobUpdateStatus]bool, size)
 	p.UpdateStatuses = tSet
 	for i := 0; i < size; i++ {
-		var _elem32 JobUpdateStatus
+		var _elem33 JobUpdateStatus
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := JobUpdateStatus(v)
-			_elem32 = temp
+			_elem33 = temp
 		}
-		p.UpdateStatuses[_elem32] = true
+		p.UpdateStatuses[_elem33] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -11662,13 +11724,13 @@ func (p *ListBackupsResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[string]bool, size)
 	p.Backups = tSet
 	for i := 0; i < size; i++ {
-		var _elem33 string
+		var _elem34 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_elem33 = v
+			_elem34 = v
 		}
-		p.Backups[_elem33] = true
+		p.Backups[_elem34] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -11774,11 +11836,11 @@ func (p *StartMaintenanceResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*HostStatus]bool, size)
 	p.Statuses = tSet
 	for i := 0; i < size; i++ {
-		_elem34 := &HostStatus{}
-		if err := _elem34.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem34), err)
+		_elem35 := &HostStatus{}
+		if err := _elem35.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem35), err)
 		}
-		p.Statuses[_elem34] = true
+		p.Statuses[_elem35] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -11884,11 +11946,11 @@ func (p *DrainHostsResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*HostStatus]bool, size)
 	p.Statuses = tSet
 	for i := 0; i < size; i++ {
-		_elem35 := &HostStatus{}
-		if err := _elem35.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem35), err)
+		_elem36 := &HostStatus{}
+		if err := _elem36.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem36), err)
 		}
-		p.Statuses[_elem35] = true
+		p.Statuses[_elem36] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -11994,11 +12056,11 @@ func (p *QueryRecoveryResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*ScheduledTask]bool, size)
 	p.Tasks = tSet
 	for i := 0; i < size; i++ {
-		_elem36 := &ScheduledTask{}
-		if err := _elem36.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem36), err)
+		_elem37 := &ScheduledTask{}
+		if err := _elem37.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem37), err)
 		}
-		p.Tasks[_elem36] = true
+		p.Tasks[_elem37] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12104,11 +12166,11 @@ func (p *MaintenanceStatusResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*HostStatus]bool, size)
 	p.Statuses = tSet
 	for i := 0; i < size; i++ {
-		_elem37 := &HostStatus{}
-		if err := _elem37.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem37), err)
+		_elem38 := &HostStatus{}
+		if err := _elem38.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem38), err)
 		}
-		p.Statuses[_elem37] = true
+		p.Statuses[_elem38] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12214,11 +12276,11 @@ func (p *EndMaintenanceResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*HostStatus]bool, size)
 	p.Statuses = tSet
 	for i := 0; i < size; i++ {
-		_elem38 := &HostStatus{}
-		if err := _elem38.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem38), err)
+		_elem39 := &HostStatus{}
+		if err := _elem39.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem39), err)
 		}
-		p.Statuses[_elem38] = true
+		p.Statuses[_elem39] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12324,11 +12386,11 @@ func (p *RoleSummaryResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*RoleSummary]bool, size)
 	p.Summaries = tSet
 	for i := 0; i < size; i++ {
-		_elem39 := &RoleSummary{}
-		if err := _elem39.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem39), err)
+		_elem40 := &RoleSummary{}
+		if err := _elem40.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem40), err)
 		}
-		p.Summaries[_elem39] = true
+		p.Summaries[_elem40] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12434,11 +12496,11 @@ func (p *JobSummaryResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*JobSummary]bool, size)
 	p.Summaries = tSet
 	for i := 0; i < size; i++ {
-		_elem40 := &JobSummary{}
-		if err := _elem40.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem40), err)
+		_elem41 := &JobSummary{}
+		if err := _elem41.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem41), err)
 		}
-		p.Summaries[_elem40] = true
+		p.Summaries[_elem41] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12643,11 +12705,11 @@ func (p *GetPendingReasonResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*PendingReason]bool, size)
 	p.Reasons = tSet
 	for i := 0; i < size; i++ {
-		_elem41 := &PendingReason{}
-		if err := _elem41.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem41), err)
+		_elem42 := &PendingReason{}
+		if err := _elem42.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem42), err)
 		}
-		p.Reasons[_elem41] = true
+		p.Reasons[_elem42] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -12901,11 +12963,11 @@ func (p *GetJobUpdateSummariesResult_) readField1(iprot thrift.TProtocol) error 
 	tSlice := make([]*JobUpdateSummary, 0, size)
 	p.UpdateSummaries = tSlice
 	for i := 0; i < size; i++ {
-		_elem42 := &JobUpdateSummary{}
-		if err := _elem42.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem42), err)
+		_elem43 := &JobUpdateSummary{}
+		if err := _elem43.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem43), err)
 		}
-		p.UpdateSummaries = append(p.UpdateSummaries, _elem42)
+		p.UpdateSummaries = append(p.UpdateSummaries, _elem43)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -13040,11 +13102,11 @@ func (p *GetJobUpdateDetailsResult_) readField2(iprot thrift.TProtocol) error {
 	tSlice := make([]*JobUpdateDetails, 0, size)
 	p.DetailsList = tSlice
 	for i := 0; i < size; i++ {
-		_elem43 := &JobUpdateDetails{}
-		if err := _elem43.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem43), err)
+		_elem44 := &JobUpdateDetails{}
+		if err := _elem44.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem44), err)
 		}
-		p.DetailsList = append(p.DetailsList, _elem43)
+		p.DetailsList = append(p.DetailsList, _elem44)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -13290,11 +13352,11 @@ func (p *GetJobUpdateDiffResult_) readField1(iprot thrift.TProtocol) error {
 	tSet := make(map[*ConfigGroup]bool, size)
 	p.Add = tSet
 	for i := 0; i < size; i++ {
-		_elem44 := &ConfigGroup{}
-		if err := _elem44.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem44), err)
+		_elem45 := &ConfigGroup{}
+		if err := _elem45.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem45), err)
 		}
-		p.Add[_elem44] = true
+		p.Add[_elem45] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -13310,11 +13372,11 @@ func (p *GetJobUpdateDiffResult_) readField2(iprot thrift.TProtocol) error {
 	tSet := make(map[*ConfigGroup]bool, size)
 	p.Remove = tSet
 	for i := 0; i < size; i++ {
-		_elem45 := &ConfigGroup{}
-		if err := _elem45.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem45), err)
+		_elem46 := &ConfigGroup{}
+		if err := _elem46.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem46), err)
 		}
-		p.Remove[_elem45] = true
+		p.Remove[_elem46] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -13330,11 +13392,11 @@ func (p *GetJobUpdateDiffResult_) readField3(iprot thrift.TProtocol) error {
 	tSet := make(map[*ConfigGroup]bool, size)
 	p.Update = tSet
 	for i := 0; i < size; i++ {
-		_elem46 := &ConfigGroup{}
-		if err := _elem46.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem46), err)
+		_elem47 := &ConfigGroup{}
+		if err := _elem47.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem47), err)
 		}
-		p.Update[_elem46] = true
+		p.Update[_elem47] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -13350,11 +13412,11 @@ func (p *GetJobUpdateDiffResult_) readField4(iprot thrift.TProtocol) error {
 	tSet := make(map[*ConfigGroup]bool, size)
 	p.Unchanged = tSet
 	for i := 0; i < size; i++ {
-		_elem47 := &ConfigGroup{}
-		if err := _elem47.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem47), err)
+		_elem48 := &ConfigGroup{}
+		if err := _elem48.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem48), err)
 		}
-		p.Unchanged[_elem47] = true
+		p.Unchanged[_elem48] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -13553,19 +13615,19 @@ func (p *TierConfig) readField2(iprot thrift.TProtocol) error {
 	tMap := make(map[string]string, size)
 	p.Settings = tMap
 	for i := 0; i < size; i++ {
-		var _key48 string
+		var _key49 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_key48 = v
+			_key49 = v
 		}
-		var _val49 string
+		var _val50 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			_val49 = v
+			_val50 = v
 		}
-		p.Settings[_key48] = _val49
+		p.Settings[_key49] = _val50
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -13711,11 +13773,11 @@ func (p *GetTierConfigResult_) readField2(iprot thrift.TProtocol) error {
 	tSet := make(map[*TierConfig]bool, size)
 	p.Tiers = tSet
 	for i := 0; i < size; i++ {
-		_elem50 := &TierConfig{}
-		if err := _elem50.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem50), err)
+		_elem51 := &TierConfig{}
+		if err := _elem51.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem51), err)
 		}
-		p.Tiers[_elem50] = true
+		p.Tiers[_elem51] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -15162,11 +15224,11 @@ func (p *Response) readField6(iprot thrift.TProtocol) error {
 	tSlice := make([]*ResponseDetail, 0, size)
 	p.Details = tSlice
 	for i := 0; i < size; i++ {
-		_elem51 := &ResponseDetail{}
-		if err := _elem51.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem51), err)
+		_elem52 := &ResponseDetail{}
+		if err := _elem52.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem52), err)
 		}
-		p.Details = append(p.Details, _elem51)
+		p.Details = append(p.Details, _elem52)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -15810,11 +15872,11 @@ func (p *RewriteConfigsRequest) readField1(iprot thrift.TProtocol) error {
 	tSlice := make([]*ConfigRewrite, 0, size)
 	p.RewriteCommands = tSlice
 	for i := 0; i < size; i++ {
-		_elem52 := &ConfigRewrite{}
-		if err := _elem52.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem52), err)
+		_elem53 := &ConfigRewrite{}
+		if err := _elem53.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem53), err)
 		}
-		p.RewriteCommands = append(p.RewriteCommands, _elem52)
+		p.RewriteCommands = append(p.RewriteCommands, _elem53)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/realis.go
+++ b/realis.go
@@ -165,7 +165,7 @@ func (r realisClient) KillInstances(key *aurora.JobKey, instances ...int32) (*au
 		instanceIds[instId] = true
 	}
 
-	resp, err := r.client.KillTasks(key, instanceIds)
+	resp, err := r.client.KillTasks(key, instanceIds, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "Error sending Kill command to Aurora Scheduler")
 	}
@@ -182,7 +182,7 @@ func (r realisClient) KillJob(key *aurora.JobKey) (*aurora.Response, error) {
 	}
 
 	if len(instanceIds) > 0 {
-		resp, err := r.client.KillTasks(key, instanceIds)
+		resp, err := r.client.KillTasks(key, instanceIds, "")
 
 		if err != nil {
 			return nil, errors.Wrap(err, "Error sending Kill command to Aurora Scheduler")


### PR DESCRIPTION
* Updated the thrift API to be compatible with Aurora 0.17.0 and updated the stubs that were generated.
* Updated thrift API calls for those that changed since version 0.16.0 (only kill tasks api changed).

Once this is merged into the master, I'll tag a release V2.0.0 indicating that this is the first release fully compatible with Aurora 0.17.0.