### PR TITLE
Vendor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # gorealis [![GoDoc](https://godoc.org/github.com/rdelval/gorealis?status.svg)](https://godoc.org/github.com/rdelval/gorealis)
 
-Go library for communicating with [Apache Aurora](https://github.com/apache/aurora).
-Named after the northern lights (Aurora Borealis).
+Go library for interacting with [Apache Aurora](https://github.com/apache/aurora).
 
 ### Aurora version compatibility
 Please see [.auroraversion](./.auroraversion) to see the latest Aurora version against which this
-library has been tested. Vendoring a working version of this library is highly recommended.
+library has been tested.
 
 ## Usage
 
@@ -17,9 +16,5 @@ library has been tested. Vendoring a working version of this library is highly r
 * Create or import a custom transport that uses https://github.com/jmcvetta/napping to improve efficiency
 * End to end testing with Vagrant setup
 
-## Importing
-* We suggest using a vendoring tool such as [govendor](https://github.com/kardianos/govendor) and
-fetching by version, for example: `govendor fetch github.com/rdelval/gorealis@v1`
-
 ## Contributions
-Contributions are very much welcome. Please raise an issue so that the contribution may be discussed before it's made.
+Contributions are always welcome. Please raise an issue so that the contribution may be discussed before it's made.

--- a/realis.go
+++ b/realis.go
@@ -31,6 +31,8 @@ import (
 	"github.com/rdelval/gorealis/response"
 )
 
+const VERSION = "1.0.4"
+
 type Realis interface {
 	AbortJobUpdate(updateKey aurora.JobUpdateKey, message string) (*aurora.Response, error)
 	AddInstances(instKey aurora.InstanceKey, count int32) (*aurora.Response, error)
@@ -225,6 +227,7 @@ func newTJSONConfig(url string, timeoutms int) (*RealisConfig, error) {
 
 	httpTrans := (trans).(*thrift.THttpClient)
 	httpTrans.SetHeader("Content-Type", "application/x-thrift")
+	httpTrans.SetHeader("User-Agent", "GoRealis v"+VERSION)
 
 	return &RealisConfig{transport: trans, protoFactory: thrift.NewTJSONProtocolFactory()}, nil
 }
@@ -237,9 +240,11 @@ func newTBinaryConfig(url string, timeoutms int) (*RealisConfig, error) {
 	}
 
 	httpTrans := (trans).(*thrift.THttpClient)
+	httpTrans.DelHeader("Content-Type") // Workaround for using thrift HttpPostClient
+
 	httpTrans.SetHeader("Accept", "application/vnd.apache.thrift.binary")
 	httpTrans.SetHeader("Content-Type", "application/vnd.apache.thrift.binary")
-	httpTrans.SetHeader("User-Agent", "GoRealis v1.0.4")
+	httpTrans.SetHeader("User-Agent", "GoRealis v"+VERSION)
 
 	return &RealisConfig{transport: trans, protoFactory: thrift.NewTBinaryProtocolFactoryDefault()}, nil
 

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -28,8 +28,10 @@ var r Realis
 var thermosPayload []byte
 
 func TestMain(m *testing.M) {
+	var err error
+
 	// New configuration to connect to Vagrant image
-	config, err := NewDefaultConfig("http://192.168.33.7:8081",10000)
+	r, err = NewDefaultClientUsingUrl("http://192.168.33.7:8081","aurora", "secret")
 	if err != nil {
 		fmt.Println("Please run vagrant box before running test suite")
 		os.Exit(1)
@@ -40,10 +42,6 @@ func TestMain(m *testing.M) {
 		fmt.Println("Error reading thermos payload file: ", err)
 		os.Exit(1)
 	}
-
-	// Configured for vagrant
-	AddBasicAuth(&config, "aurora", "secret")
-	r = NewClient(config)
 
 	os.Exit(m.Run())
 }

--- a/vendor/git.apache.org/thrift.git/lib/go/thrift/http_client.go
+++ b/vendor/git.apache.org/thrift.git/lib/go/thrift/http_client.go
@@ -103,7 +103,7 @@ func NewTHttpClientWithOptions(urlstr string, options THttpClientOptions) (TTran
 	if client == nil {
 		client = DefaultHttpClient
 	}
-	httpHeader := map[string][]string{}
+	httpHeader := map[string][]string{"Content-Type": []string{"application/x-thrift"}}
 	return &THttpClient{client: client, response: response, url: parsedURL, header: httpHeader}, nil
 }
 
@@ -121,7 +121,7 @@ func NewTHttpPostClientWithOptions(urlstr string, options THttpClientOptions) (T
 	if client == nil {
 		client = DefaultHttpClient
 	}
-	httpHeader := map[string][]string{}
+	httpHeader := map[string][]string{"Content-Type": []string{"application/x-thrift"}}
 	return &THttpClient{client: client, url: parsedURL, requestBuffer: bytes.NewBuffer(buf), header: httpHeader}, nil
 }
 


### PR DESCRIPTION
* Reverted changes to vendored go Thrift library.
* Created a workaround for using Thrift Binary protocol since the default HTTP client has headers configured for use with the Thrift JSON protocol currently.
* Cleaned up the Readme
* Updated the end to end test to mirror changes to how clients are created.